### PR TITLE
Print message when the stack is up and running

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM redhat/ubi8
 RUN mkdir /otel-lgtm
 WORKDIR /otel-lgtm
 
-RUN yum install -y unzip
+RUN yum install -y unzip jq
 
 RUN curl -sOL https://dl.grafana.com/oss/release/grafana-10.1.2.linux-amd64.tar.gz && \
     tar xfz grafana-10.1.2.linux-amd64.tar.gz && \

--- a/docker/otelcol-config.yaml
+++ b/docker/otelcol-config.yaml
@@ -3,6 +3,12 @@ receivers:
     protocols:
       grpc:
       http:
+  prometheus/collector:
+    config:
+      scrape_configs:
+        - job_name: 'opentelemetry-collector'
+          static_configs:
+            - targets: ['localhost:8888']
 
 processors:
   batch:
@@ -30,7 +36,7 @@ service:
       exporters: [otlphttp]
       #exporters: [otlphttp,logging/traces]
     metrics:
-      receivers: [otlp]
+      receivers: [otlp,prometheus/collector]
       processors: [batch]
       exporters: [prometheusremotewrite]
       #exporters: [prometheusremotewrite,logging/metrics]

--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -6,9 +6,18 @@
 ./run-prometheus.sh &
 ./run-tempo.sh &
 
+echo "Waiting for the OpenTelemetry collector and the Grafana LGTM stack to start up..."
+
+# This waits for collector metrics to be available in Prometheus.
+# TODO: Also curl Grafana, Loki, Tempo to be sure all services are up.
+while ! curl -sg 'http://localhost:9090/api/v1/query?query=up{job="opentelemetry-collector"}' | jq -r .data.result[0].value[1] | grep '1' > /dev/null ; do
+    sleep 1
+done
+
+echo "The OpenTelemtry collector and the Grafana LGTM stack are up and running!"
+
 echo "Open ports:"
 echo " - 4317: OpenTelemetry endpoint"
 echo " - 3000: Grafana. User: admin, password: admin"
-echo "It might take a minute for all services to start up"
 
 sleep infinity


### PR DESCRIPTION
Changed the startup script to print the following line when the stack is up and running:

```
The OpenTelemtry collector and the Grafana LGTM stack are up and running!
```

This should be useful for Testcontainers' [Log output Wait Strategy](https://java.testcontainers.org/features/startup_and_waits/).

---

Note: Actually the script only checks if the collector and Prometheus are up and running. This is already helpful, because it means you can successfully push telemetry to the collector and query Prometheus. However, for completeness it would be cool to check the other services as well.