### PR TITLE
Bump versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,39 +1,44 @@
 FROM redhat/ubi8
 
+ENV GRAFANA_VERSION="10.2.0"
+ENV PROMETHEUS_VERSION="2.47.2"
+ENV TEMPO_VERSION="2.2.4"
+ENV LOKI_VERSION="2.9.2"
+ENV OPENTELEMETRY_COLLECTOR_VERSION="0.88.0"
 
 RUN mkdir /otel-lgtm
 WORKDIR /otel-lgtm
 
 RUN yum install -y unzip jq
 
-RUN curl -sOL https://dl.grafana.com/oss/release/grafana-10.1.2.linux-amd64.tar.gz && \
-    tar xfz grafana-10.1.2.linux-amd64.tar.gz && \
-    rm grafana-10.1.2.linux-amd64.tar.gz
+RUN curl -sOL https://dl.grafana.com/oss/release/grafana-$GRAFANA_VERSION.linux-amd64.tar.gz && \
+    tar xfz grafana-$GRAFANA_VERSION.linux-amd64.tar.gz && \
+    rm grafana-$GRAFANA_VERSION.linux-amd64.tar.gz
 
-RUN curl -sOL https://github.com/prometheus/prometheus/releases/download/v2.47.0/prometheus-2.47.0.linux-amd64.tar.gz && \
-    tar xfz prometheus-2.47.0.linux-amd64.tar.gz && \
-    mv prometheus-2.47.0.linux-amd64 prometheus-2.47.0 && \
-    rm prometheus-2.47.0.linux-amd64.tar.gz
+RUN curl -sOL https://github.com/prometheus/prometheus/releases/download/v$PROMETHEUS_VERSION/prometheus-$PROMETHEUS_VERSION.linux-amd64.tar.gz && \
+    tar xfz prometheus-$PROMETHEUS_VERSION.linux-amd64.tar.gz && \
+    mv prometheus-$PROMETHEUS_VERSION.linux-amd64 prometheus-$PROMETHEUS_VERSION && \
+    rm prometheus-$PROMETHEUS_VERSION.linux-amd64.tar.gz
 
-RUN curl -sOL https://github.com/grafana/tempo/releases/download/v2.2.3/tempo_2.2.3_linux_amd64.tar.gz && \
-    mkdir tempo-2.2.3/ && \
-    tar xfz tempo_2.2.3_linux_amd64.tar.gz -C tempo-2.2.3/ && \
-    rm tempo_2.2.3_linux_amd64.tar.gz
+RUN curl -sOL https://github.com/grafana/tempo/releases/download/v$TEMPO_VERSION/tempo_${TEMPO_VERSION}_linux_amd64.tar.gz && \
+    mkdir tempo-$TEMPO_VERSION/ && \
+    tar xfz tempo_${TEMPO_VERSION}_linux_amd64.tar.gz -C tempo-$TEMPO_VERSION/ && \
+    rm tempo_${TEMPO_VERSION}_linux_amd64.tar.gz
 
-RUN curl -sOL https://github.com/grafana/loki/releases/download/v2.9.1/loki-linux-amd64.zip && \
-    mkdir loki-2.9.1 && \
-    unzip loki-linux-amd64 -d loki-2.9.1/ && \
+RUN curl -sOL https://github.com/grafana/loki/releases/download/v$LOKI_VERSION/loki-linux-amd64.zip && \
+    mkdir loki-$LOKI_VERSION && \
+    unzip loki-linux-amd64 -d loki-$LOKI_VERSION/ && \
     rm loki-linux-amd64.zip
 
-RUN curl -sOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.85.0/otelcol-contrib_0.85.0_linux_amd64.tar.gz && \
-    mkdir otelcol-contrib-0.85.0 && \
-    tar xfz otelcol-contrib_0.85.0_linux_amd64.tar.gz -C otelcol-contrib-0.85.0/ && \
-    rm otelcol-contrib_0.85.0_linux_amd64.tar.gz
+RUN curl -sOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$OPENTELEMETRY_COLLECTOR_VERSION/otelcol-contrib_${OPENTELEMETRY_COLLECTOR_VERSION}_linux_amd64.tar.gz && \
+    mkdir otelcol-contrib-$OPENTELEMETRY_COLLECTOR_VERSION && \
+    tar xfz otelcol-contrib_${OPENTELEMETRY_COLLECTOR_VERSION}_linux_amd64.tar.gz -C otelcol-contrib-$OPENTELEMETRY_COLLECTOR_VERSION/ && \
+    rm otelcol-contrib_${OPENTELEMETRY_COLLECTOR_VERSION}_linux_amd64.tar.gz
 
 COPY prometheus.yaml .
 COPY run-prometheus.sh .
-COPY grafana-datasources.yaml ./grafana-10.1.2/conf/provisioning/datasources/
-COPY grafana-dashboards.yaml grafana-10.1.2/conf/provisioning/dashboards/
+COPY grafana-datasources.yaml ./grafana-$GRAFANA_VERSION/conf/provisioning/datasources/
+COPY grafana-dashboards.yaml grafana-$GRAFANA_VERSION/conf/provisioning/dashboards/
 COPY grafana-dashboard-red-metrics.json .
 COPY grafana-dashboard-jvm-metrics.json .
 COPY run-grafana.sh .

--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cd ./grafana-10.1.2
+cd ./grafana-$GRAFANA_VERSION
 ./bin/grafana server > /dev/null 2>&1

--- a/docker/run-loki.sh
+++ b/docker/run-loki.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./loki-2.9.1/loki-linux-amd64  --config.file=./loki-config.yaml > /dev/null 2>&1
+./loki-$LOKI_VERSION/loki-linux-amd64  --config.file=./loki-config.yaml > /dev/null 2>&1

--- a/docker/run-otelcol.sh
+++ b/docker/run-otelcol.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./otelcol-contrib-0.85.0/otelcol-contrib --config=file:./otelcol-config.yaml --feature-gates=pkg.translator.prometheus.NormalizeName > /dev/null 2>&1
+./otelcol-contrib-$OPENTELEMETRY_COLLECTOR_VERSION/otelcol-contrib --config=file:./otelcol-config.yaml --feature-gates=pkg.translator.prometheus.NormalizeName > /dev/null 2>&1

--- a/docker/run-prometheus.sh
+++ b/docker/run-prometheus.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./prometheus-2.47.0/prometheus \
+./prometheus-$PROMETHEUS_VERSION/prometheus \
       --web.enable-remote-write-receiver \
       --enable-feature=exemplar-storage \
       --enable-feature=native-histograms \

--- a/docker/run-tempo.sh
+++ b/docker/run-tempo.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./tempo-2.2.3/tempo --config.file=./tempo-config.yaml > /dev/null 2>&1
+./tempo-$TEMPO_VERSION/tempo --config.file=./tempo-config.yaml > /dev/null 2>&1


### PR DESCRIPTION
Version bumps

* Grafana: 10.1.2 -> 10.2.0
* Prometheus: 2.47.0 ->  2.47.2
* Loki: 2.9.1 -> 2.9.2
* Tempo: 2.2.3 -> 2.2.4
* OpenTelemetry collector: 0.85.0 -> 0.88.0