### PR TITLE
Add service graph metrics

### DIFF
--- a/docker/tempo-config.yaml
+++ b/docker/tempo-config.yaml
@@ -19,12 +19,12 @@ storage:
     local:
       path: /tmp/tempo/blocks
 
-#metrics_generator:
-#  storage:
-#    path: /tmp/tempo/generator/wal
-#    remote_write:
-#      - url: http://localhost:9090/api/v1/write
-#        send_exemplars: true
+metrics_generator:
+  storage:
+    path: /tmp/tempo/generator/wal
+    remote_write:
+      - url: http://localhost:9090/api/v1/write
+        send_exemplars: true
 
-#overrides:
-#  metrics_generator_processors: [span-metrics]
+overrides:
+  metrics_generator_processors: [service-graphs]


### PR DESCRIPTION
Enable service graph metrics. The service graph can be viewed in the "Service Graph" tab in the Explore view for the Tempo data source.