### PR TITLE
Remove obsolete collector feature flag

### DIFF
--- a/docker/run-otelcol.sh
+++ b/docker/run-otelcol.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-./otelcol-contrib-$OPENTELEMETRY_COLLECTOR_VERSION/otelcol-contrib --config=file:./otelcol-config.yaml --feature-gates=pkg.translator.prometheus.NormalizeName > /dev/null 2>&1
+./otelcol-contrib-$OPENTELEMETRY_COLLECTOR_VERSION/otelcol-contrib \
+	--config=file:./otelcol-config.yaml \
+	> /dev/null 2>&1


### PR DESCRIPTION
The feature flag `pkg.translator.prometheus.NormalizeName` is no longer necessary for the OpenTelemetry collector because since [v0.85.0](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.85.0) this is the default behavior.