### PR TITLE
Use stable semantic metrics conventions in example dashboards

### DIFF
--- a/docker/grafana-dashboard-jvm-metrics.json
+++ b/docker/grafana-dashboard-jvm-metrics.json
@@ -1,35 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "datasource",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "10.1.0-57731pre"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -57,7 +26,6 @@
   "fiscalYearStartMonth": 0,
   "gnetId": 18812,
   "graphTooltip": 0,
-  "id": null,
   "links": [
     {
       "asDropdown": false,
@@ -86,6 +54,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -160,7 +129,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by (instance) (rate(http_server_duration_milliseconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum by (instance) (rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -182,6 +151,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -256,7 +226,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(sum by (instance)(rate(http_server_duration_milliseconds_count{job=~\"$job\", instance=~\"$instance\", http_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate(http_server_duration_milliseconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))\n",
+          "expr": "(sum by (instance)(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\", http_response_status_code=~\"5.*\"}[$__rate_interval]))) / on (instance) (sum by (instance)(rate(http_server_request_duration_seconds_count{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval])))\n",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -278,6 +248,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -322,7 +293,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -352,7 +323,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "(histogram_quantile(0.95, sum by(le, instance) (rate(http_server_duration_milliseconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))))",
+          "expr": "(histogram_quantile(0.95, sum by(le, instance) (rate(http_server_request_duration_seconds_bucket{job=~\"$job\", instance=~\"$instance\"}[$__rate_interval]))))",
           "instant": false,
           "legendFormat": "{{instance}}",
           "range": true,
@@ -374,6 +345,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -469,6 +441,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -564,6 +537,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -656,6 +630,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -751,6 +726,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -835,9 +811,8 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": "",
   "schemaVersion": 38,
-  "style": "dark",
   "tags": [
     "JVM",
     "open-telemetry",
@@ -851,8 +826,8 @@
       {
         "current": {
           "selected": false,
-          "text": "default",
-          "value": "default"
+          "text": "Prometheus",
+          "value": "prometheus"
         },
         "description": "Choose a Prometheus data source",
         "hide": 0,
@@ -870,7 +845,11 @@
       },
       {
         "allValue": ".+",
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
@@ -897,7 +876,11 @@
       },
       {
         "allValue": ".+",
-        "current": {},
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": {
           "type": "prometheus",
           "uid": "${datasource}"
@@ -957,6 +940,6 @@
   "timezone": "",
   "title": "JVM Overview (OpenTelemetry)",
   "uid": "b91844d7-121e-4d0a-93b8-a9c1a05703b3",
-  "version": 13,
+  "version": 1,
   "weekStart": ""
 }

--- a/docker/grafana-dashboard-red-metrics-classic.json
+++ b/docker/grafana-dashboard-red-metrics-classic.json
@@ -29,7 +29,7 @@
       },
       "description": "",
       "gridPos": {
-        "h": 2,
+        "h": 5,
         "w": 12,
         "x": 0,
         "y": 0
@@ -41,7 +41,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# RED Metrics: (r)equest rate, (e)rror rate, (d)uration",
+        "content": "# RED Metrics: (r)equest rate, (e)rror rate, (d)uration\n\nThis dashboard uses explicit bucket histograms and the stable [OpenTelemetry metrics semantic conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/).\nTo enable this for the [OpenTelemetry Java instrumentation agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/), set the following environment variables:\n\n```\nexport OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=explicit_bucket_histogram\nexport OTEL_SEMCONV_STABILITY_OPT_IN=http\n```",
         "mode": "markdown"
       },
       "pluginVersion": "10.2.0",
@@ -58,6 +58,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -71,6 +72,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -110,7 +112,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 2
+        "y": 5
       },
       "id": 1,
       "options": {
@@ -132,7 +134,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_server_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[5m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -152,6 +154,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -165,6 +168,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -204,7 +208,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 13
       },
       "id": 2,
       "options": {
@@ -226,7 +230,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(http_server_duration_milliseconds_count{job=\"$job\", instance=\"$instance\", http_status_code=~\"5..\"}[5m])) / sum(rate(http_server_duration_milliseconds_count{job=\"$job\", instance=\"$instance\"}[5m]))\n\n",
+          "expr": "sum(rate(http_server_request_duration_seconds_count{job=\"$job\", instance=\"$instance\", http_response_status_code=~\"5..\"}[5m])) / sum(rate(http_server_request_duration_seconds_count{job=\"$job\", instance=\"$instance\"}[5m]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -240,6 +244,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -267,13 +272,14 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 21
       },
       "id": 3,
       "options": {
         "displayMode": "gradient",
         "minVizHeight": 10,
         "minVizWidth": 0,
+        "namePlacement": "auto",
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -285,7 +291,7 @@
         "showUnfilled": true,
         "valueMode": "color"
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "10.2.0",
       "targets": [
         {
           "datasource": {
@@ -294,7 +300,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum by (le) (rate(http_server_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[5m]))",
+          "expr": "sum by (le) (rate(http_server_request_duration_seconds_bucket{job=\"$job\", instance=\"$instance\"}[5m]))",
           "format": "heatmap",
           "instant": false,
           "legendFormat": "{{le}}",
@@ -302,7 +308,7 @@
           "refId": "A"
         }
       ],
-      "title": "Duration histogram (ms)",
+      "title": "Duration histogram (s)",
       "type": "bargauge"
     },
     {
@@ -329,7 +335,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 29
       },
       "id": 5,
       "options": {
@@ -363,7 +369,7 @@
         "yAxis": {
           "axisPlacement": "left",
           "reverse": false,
-          "unit": "ms"
+          "unit": "s"
         }
       },
       "pluginVersion": "10.2.0",
@@ -375,7 +381,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by (le) (rate(http_server_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[5m]))",
+          "expr": "sum by (le) (rate(http_server_request_duration_seconds_bucket{job=\"$job\", instance=\"$instance\"}[5m]))",
           "format": "heatmap",
           "instant": false,
           "range": true,
@@ -396,6 +402,7 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
@@ -409,6 +416,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -440,7 +448,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -448,7 +456,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 34
+        "y": 37
       },
       "id": 4,
       "options": {
@@ -472,7 +480,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(http_server_request_duration_seconds_bucket{job=\"$job\", instance=\"$instance\"}[5m])))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "95th",
@@ -486,7 +494,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.5, sum by (le) (rate(http_server_duration_milliseconds_bucket{job=\"$job\", instance=\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(http_server_request_duration_seconds_bucket{job=\"$job\", instance=\"$instance\"}[5m])))",
           "hide": false,
           "legendFormat": "50th",
           "range": true,
@@ -504,7 +512,7 @@
     "list": [
       {
         "current": {
-          "selected": true,
+          "selected": false,
           "text": "greeting-service",
           "value": "greeting-service"
         },

--- a/docker/grafana-dashboard-red-metrics-native.json
+++ b/docker/grafana-dashboard-red-metrics-native.json
@@ -29,7 +29,7 @@
       },
       "description": "",
       "gridPos": {
-        "h": 2,
+        "h": 5,
         "w": 12,
         "x": 0,
         "y": 0
@@ -41,7 +41,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "# RED Metrics: (r)equest rate, (e)rror rate, (d)uration",
+        "content": "# RED Metrics: (r)equest rate, (e)rror rate, (d)uration\n\nThis dashboard uses exponential histograms and the stable [OpenTelemetry metrics semantic conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/).\nTo enable this for the [OpenTelemetry Java instrumentation agent](https://github.com/open-telemetry/opentelemetry-java-instrumentation/), set the following environment variables:\n\n```\nexport OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=base2_exponential_bucket_histogram\nexport OTEL_SEMCONV_STABILITY_OPT_IN=http\n```",
         "mode": "markdown"
       },
       "pluginVersion": "10.2.0",
@@ -112,7 +112,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 2
+        "y": 5
       },
       "id": 1,
       "options": {
@@ -134,7 +134,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(histogram_count(rate(http_server_duration_milliseconds{job=\"$job\", instance=\"$instance\"}[5m])))",
+          "expr": "sum(histogram_count(rate(http_server_request_duration_seconds{job=\"$job\", instance=\"$instance\"}[5m])))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -208,7 +208,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 10
+        "y": 13
       },
       "id": 2,
       "options": {
@@ -230,7 +230,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(histogram_count(rate(http_server_duration_milliseconds{job=\"$job\", instance=\"$instance\", http_status_code=~\"5..\"}[5m]))) / sum(histogram_count(rate(http_server_duration_milliseconds{job=\"$job\", instance=\"$instance\"}[5m])))\n\n",
+          "expr": "sum(histogram_count(rate(http_server_request_duration_seconds{job=\"$job\", instance=\"$instance\", http_response_status_code=~\"5..\"}[5m]))) / sum(histogram_count(rate(http_server_request_duration_seconds{job=\"$job\", instance=\"$instance\"}[5m])))\n\n",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -263,7 +263,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 21
       },
       "id": 5,
       "options": {
@@ -297,7 +297,7 @@
         "yAxis": {
           "axisPlacement": "left",
           "reverse": false,
-          "unit": "ms"
+          "unit": "s"
         }
       },
       "pluginVersion": "10.2.0",
@@ -309,7 +309,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "sum(rate(http_server_duration_milliseconds{job=\"$job\", instance=\"$instance\"}[5m]))",
+          "expr": "sum(rate(http_server_request_duration_seconds{job=\"$job\", instance=\"$instance\"}[5m]))",
           "format": "time_series",
           "instant": false,
           "range": true,
@@ -376,7 +376,7 @@
               }
             ]
           },
-          "unit": "ms"
+          "unit": "s"
         },
         "overrides": []
       },
@@ -384,7 +384,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 29
       },
       "id": 4,
       "options": {
@@ -408,7 +408,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum(rate(http_server_duration_milliseconds{job=\"$job\", instance=\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds{job=\"$job\", instance=\"$instance\"}[5m])))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "95th",
@@ -422,7 +422,7 @@
           },
           "editorMode": "code",
           "exemplar": true,
-          "expr": "histogram_quantile(0.5, sum(rate(http_server_duration_milliseconds{job=\"$job\", instance=\"$instance\"}[5m])))",
+          "expr": "histogram_quantile(0.5, sum(rate(http_server_request_duration_seconds{job=\"$job\", instance=\"$instance\"}[5m])))",
           "hide": false,
           "legendFormat": "50th",
           "range": true,

--- a/run-example.sh
+++ b/run-example.sh
@@ -8,5 +8,6 @@ if [[ ! -f ./opentelemetry-javaagent.jar ]] ; then
     curl -sOL https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.30.0/opentelemetry-javaagent.jar
 fi
 export OTEL_LOGS_EXPORTER=otlp
+export OTEL_SEMCONV_STABILITY_OPT_IN=http
 export OTEL_RESOURCE_ATTRIBUTES="service.name=example-app,service.instance.id=localhost:8080"
 java -Dotel.metric.export.interval=500 -Dotel.bsp.schedule.delay=500 -javaagent:opentelemetry-javaagent.jar -jar ./target/example-app.jar


### PR DESCRIPTION
The previous dashboards used old experimental HTTP metric names and units.

With this PR we switch to the stable [OpenTelemetry metrics semantic conventions](https://opentelemetry.io/docs/specs/semconv/general/metrics/).