### PR TITLE
Set default scrape interval to 60s

### DIFF
--- a/docker/grafana-datasources.yaml
+++ b/docker/grafana-datasources.yaml
@@ -22,6 +22,7 @@ datasources:
     uid: prometheus
     url: http://localhost:9090
     jsonData:
+      timeInterval: 60s
       exemplarTraceIdDestinations:
         - name: trace_id
           datasourceUid: tempo


### PR DESCRIPTION
The [default scrape interval in OpenTelemetry is 60 seconds](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#periodic-exporting-metricreader). We should configure the default scrape interval in the Prometheus data source accordingly to make sure queries using `$__rate_interval` work.