### PR TITLE
Java example: Redirect from root path

### DIFF
--- a/examples/java/src/main/java/com/grafana/example/RollController.java
+++ b/examples/java/src/main/java/com/grafana/example/RollController.java
@@ -11,6 +11,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 @RestController
 public class RollController {
+
     private static final Logger logger = LoggerFactory.getLogger(RollController.class);
 
     @GetMapping("/rolldice")

--- a/examples/java/src/main/java/com/grafana/example/SpringBootApp.java
+++ b/examples/java/src/main/java/com/grafana/example/SpringBootApp.java
@@ -1,10 +1,23 @@
 package com.grafana.example;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
+@RestController
 public class SpringBootApp {
+
+    /**
+     * Redirect to {@link RollController}
+     */
+    @GetMapping("/")
+    public void redirect(HttpServletResponse httpServletResponse) {
+        httpServletResponse.setHeader("Location", "/rolldice");
+        httpServletResponse.setStatus(302);
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(SpringBootApp.class, args);


### PR DESCRIPTION
The URL for the Java example is http://localhost:8080/rolldice.

This PR adds a redirect from http://localhost:8080 to http://localhost:8080/rolldice so if someone doesn't enter the path they will be redirected to the correct path.