### PR TITLE
Increase latency of the example Java service

### DIFF
--- a/examples/java/src/main/java/com/grafana/example/RollController.java
+++ b/examples/java/src/main/java/com/grafana/example/RollController.java
@@ -1,5 +1,6 @@
 package com.grafana.example;
 
+import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,13 +14,14 @@ import java.util.concurrent.ThreadLocalRandom;
 public class RollController {
 
     private static final Logger logger = LoggerFactory.getLogger(RollController.class);
+    private final Random random = new Random(0);
 
     @GetMapping("/rolldice")
-    public String index(@RequestParam("player") Optional<String> player) {
-        if (ThreadLocalRandom.current().nextInt(10) < 3) {
+    public String index(@RequestParam("player") Optional<String> player) throws InterruptedException {
+        Thread.sleep((long) (Math.abs((random.nextGaussian() + 1.0) * 200.0)));
+        if (random.nextInt(10) < 3) {
             throw new RuntimeException("simulating an error");
         }
-
         int result = this.getRandomNumber(1, 6);
         if (player.isPresent()) {
             logger.info("{} is rolling the dice: {}", player.get(), result);
@@ -30,6 +32,6 @@ public class RollController {
     }
 
     public int getRandomNumber(int min, int max) {
-        return ThreadLocalRandom.current().nextInt(min, max + 1);
+        return random.nextInt(min, max + 1);
     }
 }


### PR DESCRIPTION
Restore the random `sleep` in the example Java REST service to have more realistic latencies.

This will make OpenTelemetry's default histogram buckets fit better with the durations observed on the REST service.