### PR TITLE
Fix typo

### DIFF
--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -14,7 +14,7 @@ while ! curl -sg 'http://localhost:9090/api/v1/query?query=up{job="opentelemetry
     sleep 1
 done
 
-echo "The OpenTelemtry collector and the Grafana LGTM stack are up and running!"
+echo "The OpenTelemetry collector and the Grafana LGTM stack are up and running."
 
 echo "Open ports:"
 echo " - 4317: OpenTelemetry GRPC endpoint"


### PR DESCRIPTION
Fix typo in the startup message.

Unfortunately this will break automated tests using the message as a signal when the container is up and running.

However, let's better fix it now than wait longer.