### PR TITLE
feat(#38): Configure tempo for TraceQL metrics

### DIFF
--- a/docker/tempo-config.yaml
+++ b/docker/tempo-config.yaml
@@ -20,6 +20,11 @@ storage:
       path: /tmp/tempo/blocks
 
 metrics_generator:
+  processor:
+    local_blocks:
+      filter_server_spans: false
+  traces_storage:
+    path: /tmp/tempo/generator/traces
   storage:
     path: /tmp/tempo/generator/wal
     remote_write:
@@ -27,4 +32,4 @@ metrics_generator:
         send_exemplars: true
 
 overrides:
-  metrics_generator_processors: [service-graphs]
+  metrics_generator_processors: [service-graphs, local-blocks]


### PR DESCRIPTION
Closes #38  

See documentation https://grafana.com/docs/tempo/latest/operations/traceql-metrics/

![Screenshot 2024-05-04 163514](https://github.com/grafana/docker-otel-lgtm/assets/21075964/e04f4ab6-be40-4a43-935b-c717b0f0bad0)

