### PR TITLE
Bump loki version to 3.0.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM redhat/ubi8
 ENV GRAFANA_VERSION="10.4.1"
 ENV PROMETHEUS_VERSION="2.51.1"
 ENV TEMPO_VERSION="2.4.1"
-ENV LOKI_VERSION="2.9.6"
+ENV LOKI_VERSION="3.0.0"
 ENV OPENTELEMETRY_COLLECTOR_VERSION="0.97.0"
 
 # TARGETARCH is automatically detected and set by the Docker daemon during the build process. If the build starts

--- a/docker/loki-config.yaml
+++ b/docker/loki-config.yaml
@@ -17,9 +17,9 @@ common:
 schema_config:
   configs:
     - from: 2020-10-24
-      store: boltdb-shipper
+      store: tsdb
       object_store: filesystem
-      schema: v11
+      schema: v13
       index:
         prefix: index_
         period: 24h


### PR DESCRIPTION
- part of #40
  - This is a prerequisite for `Replace lokiexporter to otlpexporter`.
  - Split this atomically, before activating OTLP

### tests

- passed https://github.com/arukiidou/docker-otel-lgtm/pull/1
ok

```bash
curl -H 'Content-Type: application/json' -X POST -s 'http://localhost:3100/loki/api/v1/push' --data-raw '{
  "streams": [
    {
      "stream": {
        "ore": "are"
      },
      "values": [
          [ "1715133513448000111" , "this is log" ]
      ]
    }
  ]
}'
```

![image](https://github.com/grafana/docker-otel-lgtm/assets/10738333/67e7920e-575f-40a5-95f9-1601221479ea)

