### PR TITLE
Replace prometheusremotewriteexporter to otlpexporter

### DIFF
--- a/docker/otelcol-config.yaml
+++ b/docker/otelcol-config.yaml
@@ -16,7 +16,7 @@ processors:
 exporters:
   otlp/metrics:
     endpoint: http://localhost:9090/api/v1/otlp
-  otlphttp:
+  otlp/traces:
     endpoint: http://localhost:4418
   loki:
     endpoint: http://localhost:3100/loki/api/v1/push
@@ -32,8 +32,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlphttp]
-      #exporters: [otlphttp,logging/traces]
+      exporters: [otlp/traces]
+      #exporters: [otlp/traces,logging/traces]
     metrics:
       receivers: [otlp,prometheus/collector]
       processors: [batch]

--- a/docker/otelcol-config.yaml
+++ b/docker/otelcol-config.yaml
@@ -14,9 +14,8 @@ processors:
   batch:
 
 exporters:
-  prometheusremotewrite:
-    endpoint: http://localhost:9090/api/v1/write
-    add_metric_suffixes: true
+  otlp/metrics:
+    endpoint: http://localhost:9090/api/v1/otlp
   otlphttp:
     endpoint: http://localhost:4418
   loki:
@@ -38,8 +37,8 @@ service:
     metrics:
       receivers: [otlp,prometheus/collector]
       processors: [batch]
-      exporters: [prometheusremotewrite]
-      #exporters: [prometheusremotewrite,logging/metrics]
+      exporters: [otlp/metrics]
+      #exporters: [otlp/metrics,logging/metrics]
     logs:
       receivers: [otlp]
       processors: [batch]

--- a/docker/prometheus.yaml
+++ b/docker/prometheus.yaml
@@ -1,1 +1,5 @@
-# empty
+storage:
+  tsdb:
+    # A 10min time window is enough because it can easily absorb retries and network delays.
+    out_of_order_time_window: 10m
+

--- a/docker/run-prometheus.sh
+++ b/docker/run-prometheus.sh
@@ -2,6 +2,7 @@
 
 ./prometheus-$PROMETHEUS_VERSION/prometheus \
       --web.enable-remote-write-receiver \
+      --enable-feature=otlp-write-receiver \
       --enable-feature=exemplar-storage \
       --enable-feature=native-histograms \
       --storage.tsdb.path=/data/prometheus \

--- a/docker/tempo-config.yaml
+++ b/docker/tempo-config.yaml
@@ -27,6 +27,7 @@ metrics_generator:
     path: /tmp/tempo/generator/traces
   storage:
     path: /tmp/tempo/generator/wal
+    # TODO: support otlp at metrics_generator
     remote_write:
       - url: http://localhost:9090/api/v1/write
         send_exemplars: true


### PR DESCRIPTION
- part of #40 
  - [x]   - Enable out_of_order_time_window in prometheus 
  - [x]   - Replace prometheusremotewriteexporter to otlpexporter

loki not included in this PR.

## Principle

Follow the example of otel-collector docs.
https://opentelemetry.io/docs/collector/configuration/#basics

###  Why didn't replace remote_write in metrics_generator?

`metrics_generator` have not have `otlp_write` yet.
https://grafana.com/docs/tempo/latest/configuration/#metrics-generator

### Why enable out_of_order_time_window ?

https://grafana.com/blog/2023/07/20/a-practical-guide-to-data-collection-with-opentelemetry-and-prometheus/#7-configure-out-of-order-ooo-writes

```
There are no guarantees that OpenTelemetry data will arrive in order. However, Prometheus expects data to be in order by default. This is one of the nicer properties of a scrape-based system in which the timing is controlled centrally, and it allows substantial efficiency gains.

Yet, because of this data may be dropped if sending OTel data directly to Prometheus.

The fix is easy: Simply [enable OOO ingestion in Prometheus](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tsdb):
```

## TESTS

- passed acceptance-tests. https://github.com/arukiidou/docker-otel-lgtm/pull/2
- passed prometheus/tempo checks - LGTM.
- Another issue is open: #43

[lgtm-dashboard.json](https://github.com/grafana/docker-otel-lgtm/files/15239578/lgtm-dashboard.json)

![image](https://github.com/grafana/docker-otel-lgtm/assets/10738333/61bcec67-c15a-491a-8c81-bc82c806aac7)

![image](https://github.com/grafana/docker-otel-lgtm/assets/10738333/24482ceb-d74c-4058-b8ef-fc45e9d07dbb)
