### PR TITLE
 Replace lokiexporter to otlpexporter

### DIFF
--- a/docker/loki-config.yaml
+++ b/docker/loki-config.yaml
@@ -14,6 +14,9 @@ common:
     kvstore:
       store: inmemory
 
+limits_config:
+  allow_structured_metadata: true
+
 schema_config:
   configs:
     - from: 2020-10-24

--- a/docker/loki-config.yaml
+++ b/docker/loki-config.yaml
@@ -14,9 +14,6 @@ common:
     kvstore:
       store: inmemory
 
-limits_config:
-  allow_structured_metadata: true
-
 schema_config:
   configs:
     - from: 2020-10-24

--- a/docker/otelcol-config.yaml
+++ b/docker/otelcol-config.yaml
@@ -18,7 +18,7 @@ exporters:
     endpoint: http://localhost:9090/api/v1/otlp
   otlphttp/traces:
     endpoint: http://localhost:4418
-  otlp/logs:
+  otlphttp/logs:
     endpoint: http://localhost:3100/otlp
   logging/metrics:
     verbosity: detailed
@@ -42,5 +42,5 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlp/logs]
-      #exporters: [otlp/logs,logging/logs]
+      exporters: [otlphttp/logs]
+      #exporters: [otlphttp/logs,logging/logs]

--- a/docker/otelcol-config.yaml
+++ b/docker/otelcol-config.yaml
@@ -19,8 +19,8 @@ exporters:
     add_metric_suffixes: true
   otlphttp:
     endpoint: http://localhost:4418
-  loki:
-    endpoint: http://localhost:3100/loki/api/v1/push
+  otlp/logs:
+    endpoint: http://localhost:3100/otlp
   logging/metrics:
     verbosity: detailed
   logging/traces:
@@ -43,5 +43,5 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [loki]
-      #exporters: [loki,logging/logs]
+      exporters: [otlp/logs]
+      #exporters: [otlp/logs,logging/logs]


### PR DESCRIPTION
- close #40 
  - blocked by #41

## ingest endpoint

- collector otlp endpoint: `http://localhost:4318/v1/logs`
OR
- loki otlp endpoint: `http://localhost:3100/otlp/v1/logs`(exporter: `http://localhost:3100/otlp` )

### guide
https://grafana.com/docs/loki/latest/send-data/otel/#configure-the-opentelemetry-collector-to-write-logs-into-loki
### source
https://github.com/grafana/loki/blob/19fef9355fdd46911611dbec25df0f5a4e397d31/pkg/loki/modules.go#L370

### TESTS

✅OK

```bash
curl -H 'Content-Type: application/json' -X POST -v -s 'http://localhost:3100/otlp/v1/logs' --data-raw '{
...
}'

# *   Trying ::1...
# * TCP_NODELAY set
# * Connected to localhost (::1) port 3100 (#0)
# > POST /otlp/v1/logs HTTP/1.1
# > Host: localhost:3100
# > User-Agent: curl/7.61.1
# > Accept: */*
# > Content-Type: application/json
# > Content-Length: 2844
# > Expect: 100-continue
# > 
# < HTTP/1.1 100 Continue
# * We are completely uploaded and fine
# < HTTP/1.1 204 No Content
# < Date: Wed, 15 May 2024 09:55:17 GMT
# < 
# * Connection #0 to host localhost left intact
```

![image](https://github.com/grafana/docker-otel-lgtm/assets/10738333/3582c004-4bdd-4af6-974e-cf4b2d243a02)

see: https://github.com/open-telemetry/opentelemetry-proto/blob/main/examples/logs.json

```json
{
  "resourceLogs": [
    {
      "resource": {
        "attributes": [
          {
            "key": "service.name",
            "value": {
              "stringValue": "rolldice"
            }
          },
          {
            "key": "job",
            "value": {
              "stringValue": "rolldice"
            }
          }
        ]
      },
      "scopeLogs": [
        {
          "scope": {
            "name": "my.library",
            "version": "1.0.0",
            "attributes": [
              {
                "key": "my.scope.attribute",
                "value": {
                  "stringValue": "some scope attribute"
                }
              }
            ]
          },
          "logRecords": [
            {
              "timeUnixNano": "1715766897500000111",
              "observedTimeUnixNano": "1715766897500000111",
              "severityNumber": 10,
              "severityText": "Information",
              "traceId": "c29e156486ccf3d30dde0491b4429d23",
              "spanId": "92e790ce6a007caa",
              "body": {
                "stringValue": "Example log record"
              },
              "attributes": [
                {
                  "key": "string.attribute",
                  "value": {
                    "stringValue": "some string"
                  }
                },
                {
                  "key": "boolean.attribute",
                  "value": {
                    "boolValue": true
                  }
                },
                {
                  "key": "int.attribute",
                  "value": {
                    "intValue": "10"
                  }
                },
                {
                  "key": "double.attribute",
                  "value": {
                    "doubleValue": 637.704
                  }
                },
                {
                  "key": "array.attribute",
                  "value": {
                    "arrayValue": {
                      "values": [
                        {
                          "stringValue": "many"
                        },
                        {
                          "stringValue": "values"
                        }
                      ]
                    }
                  }
                },
                {
                  "key": "map.attribute",
                  "value": {
                    "kvlistValue": {
                      "values": [
                        {
                          "key": "some.map.key",
                          "value": {
                            "stringValue": "some value"
                          }
                        }
                      ]
                    }
                  }
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}
```