### PR TITLE
Move executables to non-versioned folders

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,32 +19,33 @@ RUN yum install -y unzip jq procps
 
 RUN curl -sOL https://dl.grafana.com/oss/release/grafana-$GRAFANA_VERSION.linux-${TARGETARCH}.tar.gz && \
     tar xfz grafana-$GRAFANA_VERSION.linux-${TARGETARCH}.tar.gz && \
-    rm grafana-$GRAFANA_VERSION.linux-${TARGETARCH}.tar.gz
+    rm grafana-$GRAFANA_VERSION.linux-${TARGETARCH}.tar.gz && \
+    mv grafana-v$GRAFANA_VERSION grafana/
 
 RUN curl -sOL https://github.com/prometheus/prometheus/releases/download/v$PROMETHEUS_VERSION/prometheus-$PROMETHEUS_VERSION.linux-${TARGETARCH}.tar.gz && \
     tar xfz prometheus-$PROMETHEUS_VERSION.linux-${TARGETARCH}.tar.gz && \
-    mv prometheus-$PROMETHEUS_VERSION.linux-${TARGETARCH} prometheus-$PROMETHEUS_VERSION && \
+    mv prometheus-$PROMETHEUS_VERSION.linux-${TARGETARCH} prometheus && \
     rm prometheus-$PROMETHEUS_VERSION.linux-${TARGETARCH}.tar.gz
 
 RUN curl -sOL https://github.com/grafana/tempo/releases/download/v$TEMPO_VERSION/tempo_${TEMPO_VERSION}_linux_${TARGETARCH}.tar.gz && \
-    mkdir tempo-$TEMPO_VERSION/ && \
-    tar xfz tempo_${TEMPO_VERSION}_linux_${TARGETARCH}.tar.gz -C tempo-$TEMPO_VERSION/ && \
+    mkdir tempo && \
+    tar xfz tempo_${TEMPO_VERSION}_linux_${TARGETARCH}.tar.gz -C tempo/ && \
     rm tempo_${TEMPO_VERSION}_linux_${TARGETARCH}.tar.gz
 
 RUN curl -sOL https://github.com/grafana/loki/releases/download/v$LOKI_VERSION/loki-linux-${TARGETARCH}.zip && \
-    mkdir loki-$LOKI_VERSION && \
-    unzip loki-linux-${TARGETARCH} -d loki-$LOKI_VERSION/ && \
+    mkdir loki && \
+    unzip loki-linux-${TARGETARCH} -d loki/ && \
     rm loki-linux-${TARGETARCH}.zip
 
 RUN curl -sOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v$OPENTELEMETRY_COLLECTOR_VERSION/otelcol-contrib_${OPENTELEMETRY_COLLECTOR_VERSION}_linux_${TARGETARCH}.tar.gz && \
-    mkdir otelcol-contrib-$OPENTELEMETRY_COLLECTOR_VERSION && \
-    tar xfz otelcol-contrib_${OPENTELEMETRY_COLLECTOR_VERSION}_linux_${TARGETARCH}.tar.gz -C otelcol-contrib-$OPENTELEMETRY_COLLECTOR_VERSION/ && \
+    mkdir otelcol-contrib && \
+    tar xfz otelcol-contrib_${OPENTELEMETRY_COLLECTOR_VERSION}_linux_${TARGETARCH}.tar.gz -C otelcol-contrib/ && \
     rm otelcol-contrib_${OPENTELEMETRY_COLLECTOR_VERSION}_linux_${TARGETARCH}.tar.gz
 
 COPY prometheus.yaml .
 COPY run-prometheus.sh .
-COPY grafana-datasources.yaml ./grafana-v$GRAFANA_VERSION/conf/provisioning/datasources/
-COPY grafana-dashboards.yaml grafana-v$GRAFANA_VERSION/conf/provisioning/dashboards/
+COPY grafana-datasources.yaml ./grafana/conf/provisioning/datasources/
+COPY grafana-dashboards.yaml ./grafana/conf/provisioning/dashboards/
 COPY grafana-dashboard-red-metrics-classic.json .
 COPY grafana-dashboard-red-metrics-native.json .
 COPY grafana-dashboard-jvm-metrics.json .
@@ -57,4 +58,4 @@ COPY otelcol-config.yaml .
 COPY run-otelcol.sh .
 COPY run-all.sh .
 
-CMD ./run-all.sh
+CMD /otel-lgtm/run-all.sh

--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cd ./grafana-v$GRAFANA_VERSION
+cd ./grafana
 ./bin/grafana server > /dev/null 2>&1

--- a/docker/run-loki.sh
+++ b/docker/run-loki.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./loki-$LOKI_VERSION/loki-linux-${TARGETARCH}  --config.file=./loki-config.yaml > /dev/null 2>&1
+./loki/loki-linux-${TARGETARCH}  --config.file=./loki-config.yaml > /dev/null 2>&1

--- a/docker/run-otelcol.sh
+++ b/docker/run-otelcol.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-./otelcol-contrib-$OPENTELEMETRY_COLLECTOR_VERSION/otelcol-contrib \
+./otelcol-contrib/otelcol-contrib \
 	--config=file:./otelcol-config.yaml \
 	> /dev/null 2>&1

--- a/docker/run-prometheus.sh
+++ b/docker/run-prometheus.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-./prometheus-$PROMETHEUS_VERSION/prometheus \
+./prometheus/prometheus \
       --web.enable-remote-write-receiver \
       --enable-feature=otlp-write-receiver \
       --enable-feature=exemplar-storage \

--- a/docker/run-tempo.sh
+++ b/docker/run-tempo.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./tempo-$TEMPO_VERSION/tempo --config.file=./tempo-config.yaml > /dev/null 2>&1
+./tempo/tempo --config.file=./tempo-config.yaml > /dev/null 2>&1


### PR DESCRIPTION
This change moves all versioned folders to non-versioned folders. The main advantage is the ability to mount config files in a standard location, instead of a location that contains each component's version.

This eases the update process of the container image, without needing to change both image tag and (for example) grafana version.

In my use-case, I run this container locally for development purposes, therefor, I would like to mount the Grafana config file where I disable the authentication, so I don't get the annoying "login with admin/admin and skip changing password".


Previously you had to: 
```
# Mount Grafana config in container
docker run -v "$(pwd)/grafana.ini:/otel-lgtm/grafana-v11.0.0/conf/custom.ini" grafana/otel-lgtm
```

Now you can use:
```
# Mount Grafana config in container
docker run -v "$(pwd)/grafana.ini:/otel-lgtm/grafana/conf/custom.ini" grafana/otel-lgtm
```
