### PR TITLE
Add Windows support for main scripts (run and build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,20 @@ The `grafana/otel-lgtm` Docker image is an open source backend for OpenTelemetry
 
 ## Get the Docker image
 
-The Docker image is available on Docker hub: https://hub.docker.com/r/grafana/otel-lgtm
+The Docker image is available on Docker hub: <https://hub.docker.com/r/grafana/otel-lgtm>
 
 ## Run the Docker image
 
 ```sh
+# Unix/Linux
 ./run-lgtm.sh
+
+# Windows (PowerShell)
+./run-lgtm
 ```
 
 ## Run lgtm in kubernetes
+
 ```sh
 # create k8s resources
 kubectl apply -f k8s/lgtm.yaml
@@ -55,19 +60,27 @@ docker build . -t grafana/otel-lgtm
 Run the example REST service:
 
 ```sh
+# Unix/Linux
 ./run-example.sh
+
+# Windows (PowerShell)
+./run-example
 ```
 
 Generate traffic:
 
 ```sh
+# Unix/Linux
 ./generate-traffic.sh
+
+# Windows (PowerShell)
+./generate-traffic
 ```
 
 ## Run example apps in different languages
 
 The example apps are in the `examples/` directory.
-Each example has a `run.sh` script to start the app.
+Each example has a `run.sh` or `run.cmd` script to start the app.
 
 Every example implements a rolldice service, which returns a random number between 1 and 6.
 
@@ -82,4 +95,4 @@ Each example uses a different application port (to be able to run all applicatio
 
 ## Related Work
 
-* Metrics, Logs, Traces and Profiles in Grafana: https://github.com/grafana/intro-to-mltp
+* Metrics, Logs, Traces and Profiles in Grafana: <https://github.com/grafana/intro-to-mltp>

--- a/build-lgtm.cmd
+++ b/build-lgtm.cmd
@@ -1,0 +1,28 @@
+@echo off
+
+SET release_tag=latest
+if not "%~1"=="" (
+	SET release_tag=%1
+)
+
+WHERE /Q podman
+if not ERRORLEVEL 1 (
+	goto use_podman
+)
+
+WHERE /Q docker
+if not ERRORLEVEL 1 (
+	goto use_docker
+)
+
+:no_executable_found
+echo Please install Podman or docker
+goto:EOF
+
+:use_podman
+podman buildx build -f docker/Dockerfile docker --tag grafana/otel-lgtm:%release_tag%
+goto:EOF
+
+:use_docker
+docker buildx build -f docker/Dockerfile docker --tag grafana/otel-lgtm:%release_tag%
+goto:EOF

--- a/build-lgtm.sh
+++ b/build-lgtm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-RELEASE=${1:-dev}
+RELEASE=${1:-latest}
 
 docker buildx build -f docker/Dockerfile docker --tag grafana/otel-lgtm:${RELEASE}

--- a/examples/java/run.cmd
+++ b/examples/java/run.cmd
@@ -1,0 +1,16 @@
+@REM @echo off
+
+if not exist ./target/rolldice.jar (
+    mvnw clean package
+)
+
+set version=v2.1.0
+set jar=opentelemetry-javaagent-%version%.jar
+if not exist ./%jar% (
+    curl -sL https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/%version%/opentelemetry-javaagent.jar -o %jar%
+)
+
+set OTEL_RESOURCE_ATTRIBUTES=service.name=rolldice,service.instance.id=localhost:8080
+@REM uncomment the next line to switch to Prometheus native histograms.
+@REM set OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION=base2_exponential_bucket_histogram
+java -Dotel.metric.export.interval=500 -Dotel.bsp.schedule.delay=500 -javaagent:%jar% -jar ./target/rolldice.jar

--- a/generate-traffic.cmd
+++ b/generate-traffic.cmd
@@ -1,0 +1,9 @@
+@ECHO OFF
+:loop
+	cls
+	curl -s http://localhost:8080/rolldice
+	curl -s http://localhost:8081/rolldice
+	curl -s http://localhost:8082/rolldice
+	curl -s http://localhost:8083/rolldice
+	timeout /t 2
+goto loop

--- a/run-example.cmd
+++ b/run-example.cmd
@@ -1,0 +1,4 @@
+@echo off
+
+cd examples/java
+run

--- a/run-lgtm.cmd
+++ b/run-lgtm.cmd
@@ -1,0 +1,54 @@
+@echo off
+
+SET release_tag=latest
+if not "%~1"=="" (
+	SET release_tag=%1
+)
+
+mkdir "container/grafana"
+mkdir "container/prometheus"
+mkdir "container/loki"
+
+WHERE /Q podman
+if not ERRORLEVEL 1 (
+	goto use_podman
+)
+
+WHERE /Q docker
+if not ERRORLEVEL 1 (
+	goto use_docker
+)
+
+:no_executable_found
+echo Please install Podman or docker
+goto:EOF
+
+:use_podman
+podman run ^
+	--name lgtm ^
+	-p 3000:3000 ^
+	-p 4317:4317 ^
+	-p 4318:4318 ^
+	--rm ^
+	-ti ^
+	-v ./container/grafana:/data/grafana ^
+	-v ./container/prometheus:/data/prometheus ^
+	-v ./container/loki:/loki ^
+	-e GF_PATHS_DATA=/data/grafana ^
+	docker.io/grafana/otel-lgtm:%release_tag%
+goto:EOF
+
+:use_docker
+docker run ^
+	--name lgtm ^
+	-p 3000:3000 ^
+	-p 4317:4317 ^
+	-p 4318:4318 ^
+	--rm ^
+	-ti ^
+	-v ./container/grafana:/data/grafana ^
+	-v ./container/prometheus:/data/prometheus ^
+	-v ./container/loki:/loki ^
+	-e GF_PATHS_DATA=/data/grafana ^
+	docker.io/grafana/otel-lgtm:%release_tag%
+goto:EOF

--- a/run-lgtm.sh
+++ b/run-lgtm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RELEASE=${1:-dev}
+RELEASE=${1:-latest}
 
 docker run \
   --name lgtm \


### PR DESCRIPTION
Closes #63 

Changes:
- Make `latest` the default tag
- Add  Windows compatibility for main scripts
- New Windows scripts support both Podman and Docker
- Only Java example is currently Windows compatible. 

Note:
- Current sh scripts are still Docker only compatible