### PR TITLE
Add http scheme

### DIFF
--- a/docker/otelcol-config.yaml
+++ b/docker/otelcol-config.yaml
@@ -15,15 +15,15 @@ processors:
 
 exporters:
   otlphttp/metrics:
-    endpoint: localhost:9090/api/v1/otlp
+    endpoint: http://localhost:9090/api/v1/otlp
     tls:
       insecure: true
   otlphttp/traces:
-    endpoint: localhost:4418
+    endpoint: http://localhost:4418
     tls:
       insecure: true
   otlphttp/logs:
-    endpoint: localhost:3100/otlp
+    endpoint: http://localhost:3100/otlp
     tls:
       insecure: true
   logging/metrics:


### PR DESCRIPTION
[grpc exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlpexporter#advanced-configuration)  and receivers not required http scheme.

```
exporters:
  otlp:
    endpoint: otelcol2:4317
```

but,[http exporter](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter/otlphttpexporter)
required URL scheme.

```
exporters:
  otlphttp:
    endpoint: https://example.com:4318
```
