### PR TITLE
Bump dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM redhat/ubi8
 
-ENV GRAFANA_VERSION="11.0.0"
-ENV PROMETHEUS_VERSION="2.52.0"
+ENV GRAFANA_VERSION="11.1.0"
+ENV PROMETHEUS_VERSION="2.53.1"
 ENV TEMPO_VERSION="2.5.0"
-ENV LOKI_VERSION="3.0.0"
+ENV LOKI_VERSION="3.1.0"
 ENV OPENTELEMETRY_COLLECTOR_VERSION="0.103.0"
 
 # TARGETARCH is automatically detected and set by the Docker daemon during the build process. If the build starts


### PR DESCRIPTION
- Grafana: 11.0.0 -> 11.1.0
- Prometheus: 2.52.0 -> 2.53.1
- Loki: 3.0.0 -> 3.1.0

# note
- note: Please merge #73 first