### PR TITLE
add integration test for docker lgtm image

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -12,13 +12,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: grafana/oats
-          ref: 4e02b327cf997bc21c4b64dea1951ce3f6361c68
+          ref: d07befda3cfa162865d8081aa64501ea26578870
           path: oats
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.21'
           cache-dependency-path: oats/go.sum
+      - name: Build Image for integration tests
+        run: ./build-lgtm.sh
       - name: Run acceptance tests
         run: ./scripts/run-acceptance-tests.sh
       - name: upload log file

--- a/examples/dotnet/docker-compose.oats.yml
+++ b/examples/dotnet/docker-compose.oats.yml
@@ -7,5 +7,5 @@ services:
     ports:
       - 8080:8083
     environment:
-      - Otlp__Endpoint=http://collector:4317
+      - Otlp__Endpoint=http://lgtm:4317
       - OTEL_METRIC_EXPORT_INTERVAL=5000  # so we don't have to wait 60s for metrics

--- a/examples/dotnet/oats.yaml
+++ b/examples/dotnet/oats.yaml
@@ -1,6 +1,6 @@
 # OATS is an acceptance testing framework for OpenTelemetry - https://github.com/grafana/oats/tree/main/yaml
 docker-compose:
-  generator: lgtm
+  generator: docker-lgtm
   files:
     - ./docker-compose.oats.yml
 input:

--- a/examples/dotnet/oats.yaml
+++ b/examples/dotnet/oats.yaml
@@ -17,6 +17,6 @@ expected:
     - promql: 'http_server_active_requests{http_request_method="GET"}'
       value: ">= 0"
   logs:
-    - logql: '{exporter="OTLP"} | json | body =~ `Anonymous player is rolling the dice.*`'
+    - logql: '{service_name="rolldice"} |~ `Anonymous player is rolling the dice.*`'
       contains:
         - 'Anonymous player is rolling the dice'

--- a/examples/go/docker-compose.oats.yml
+++ b/examples/go/docker-compose.oats.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://collector:4318
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
       OTEL_METRIC_EXPORT_INTERVAL: "5000"  # so we don't have to wait 60s for metrics
     ports:
       - "8080:8081"

--- a/examples/go/oats.yaml
+++ b/examples/go/oats.yaml
@@ -1,6 +1,6 @@
 # OATS is an acceptance testing framework for OpenTelemetry - https://github.com/grafana/oats/tree/main/yaml
 docker-compose:
-  generator: lgtm
+  generator: docker-lgtm
   files:
     - ./docker-compose.oats.yml
 input:

--- a/examples/python/docker-compose.oats.yml
+++ b/examples/python/docker-compose.oats.yml
@@ -7,6 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
+      OTEL_SERVICE_NAME: "rolldice"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
       OTEL_METRIC_EXPORT_INTERVAL: "5000"  # so we don't have to wait 60s for metrics
     ports:

--- a/examples/python/docker-compose.oats.yml
+++ b/examples/python/docker-compose.oats.yml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
     environment:
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://collector:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
       OTEL_METRIC_EXPORT_INTERVAL: "5000"  # so we don't have to wait 60s for metrics
     ports:
       - "8080:8082"

--- a/examples/python/oats.yaml
+++ b/examples/python/oats.yaml
@@ -1,6 +1,6 @@
 # OATS is an acceptance testing framework for OpenTelemetry - https://github.com/grafana/oats/tree/main/yaml
 docker-compose:
-  generator: lgtm
+  generator: docker-lgtm
   files:
     - ./docker-compose.oats.yml
 input:

--- a/examples/python/oats.yaml
+++ b/examples/python/oats.yaml
@@ -16,6 +16,6 @@ expected:
     - promql: 'http_server_active_requests{http_method="GET"}'
       value: ">= 0"
   logs:
-    - logql: '{exporter="OTLP"} | json | body =~ `Anonymous player is rolling the dice.*`'
+    - logql: '{service_name="rolldice"} |~ `Anonymous player is rolling the dice.*`'
       contains:
         - 'Anonymous player is rolling the dice'


### PR DESCRIPTION
which would have avoided https://github.com/grafana/docker-otel-lgtm/releases/tag/v0.7.0

based on https://github.com/grafana/oats/pull/43