### PR TITLE
fix: pod startup on openshift

### DIFF
--- a/k8s/lgtm.yaml
+++ b/k8s/lgtm.yaml
@@ -46,3 +46,21 @@ spec:
               command:
                 - cat
                 - /tmp/ready
+      # NOTE: By default OpenShift does not allow writing the root directory.
+      # Thats why the data dirs for grafana, prometheus and loki can not be 
+      # created and the pod never becomes ready.
+      # See: https://github.com/grafana/docker-otel-lgtm/issues/132
+          volumeMounts:
+            - name: grafana-data
+              mountPath: /otel-lgtm/grafana/data
+            - name: loki-storage
+              mountPath: /loki
+            - name: p8s-storage
+              mountPath: /data/prometheus
+      volumes:
+        - name: grafana-data
+          emptyDir: {}
+        - name: loki-storage
+          emptyDir: {}
+        - name: p8s-storage
+          emptyDir: {}


### PR DESCRIPTION
Closes #132

Testing:
```bash
oc apply -f https://raw.githubusercontent.com/frzifus/docker-otel-lgtm/fd2e5b1687a3d86d27ad04384f2740f1b2a4154d/k8s/lgtm.yaml
```

```
╭─     ~/gi/go/o/docker-otel-lgtm/k8s    main *1 +1 ?3
╰─❯ oc version                 
Client Version: 4.16.3
Server Version: 4.16.5
Kubernetes Version: v1.29.6+aba1e8d
╭─     ~/gi/go/o/docker-otel-lgtm/k8s    openshift *1 ?3
╰─❯ oc get pods      
NAME                    READY   STATUS    RESTARTS   AGE
lgtm-669d9bf776-ljq8m   1/1     Running   0          7m18s
```