### PR TITLE
Put data storage for all services in the /data folder so persistent volumes can be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ You can enable logging for troubleshooting:
 
 This has nothing to do with the application logs, which are collected by OpenTelemetry.
 
+#### Persist data across container instantiation
+
+The various components in the repo are configured to write their data to the /data
+directory. If you need to persist data across containers being created and destroyed,
+you can mount a volume to the /data directory. Note that this image is intended for
+development, demo, and testing environments and persisting data to an external volume
+doesn't change that. However, this feature could be useful in certain cases for 
+some users even in testing situations.
+
 ## Run lgtm in kubernetes
 
 ```sh

--- a/docker/loki-config.yaml
+++ b/docker/loki-config.yaml
@@ -4,11 +4,11 @@ server:
   http_listen_port: 3100
 
 common:
-  path_prefix: /loki
+  path_prefix: /data/loki
   storage:
     filesystem:
-      chunks_directory: /loki/chunks
-      rules_directory: /loki/rules
+      chunks_directory: /data/loki/chunks
+      rules_directory: /data/loki/rules
   replication_factor: 1
   ring:
     kvstore:

--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -5,5 +5,10 @@ source ./logging.sh
 export GF_AUTH_ANONYMOUS_ENABLED=true
 export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
 
+export GF_PATHS_HOME=/data/grafana
+export GF_PATHS_DATA=/data/grafana/data
+export GF_PATHS_PLUGINS=/data/grafana/plugins
+
+
 cd ./grafana
 run_with_logging "Grafana ${GRAFANA_VERSION}" "${ENABLE_LOGS_GRAFANA:-false}" ./bin/grafana server

--- a/docker/run-loki.sh
+++ b/docker/run-loki.sh
@@ -2,4 +2,6 @@
 
 source ./logging.sh
 
+mkdir -p /data/loki
+
 run_with_logging "Loki ${LOKI_VERSION}" "${ENABLE_LOGS_LOKI:-false}" ./loki/loki-linux-${TARGETARCH}  --config.file=./loki-config.yaml

--- a/docker/tempo-config.yaml
+++ b/docker/tempo-config.yaml
@@ -15,18 +15,18 @@ storage:
   trace:
     backend: local
     wal:
-      path: /tmp/tempo/wal
+      path: /data/tempo/wal
     local:
-      path: /tmp/tempo/blocks
+      path: /data/tempo/blocks
 
 metrics_generator:
   processor:
     local_blocks:
       filter_server_spans: false
   traces_storage:
-    path: /tmp/tempo/generator/traces
+    path: /data/tempo/generator/traces
   storage:
-    path: /tmp/tempo/generator/wal
+    path: /data/tempo/generator/wal
     # TODO: support otlp at metrics_generator
     remote_write:
       - url: http://localhost:9090/api/v1/write


### PR DESCRIPTION
In response to the other threads in the 'Issues' section of this repo and my own needs, I made an attempt to configure the various components to store their data in a common /data folder, which can then be bound to a persistent volume to persist data across containers being created and destroyed. This could potentially be useful for testing or for using this image behind a managed service such as ECS or EKS where the orchestration layer might destroy and recreate containers.

