### PR TITLE
Prometheus config: activate `keep_identifying_resource_attributes`

### DIFF
--- a/docker/prometheus.yaml
+++ b/docker/prometheus.yaml
@@ -1,5 +1,6 @@
 ---
 otlp:
+  keep_identifying_resource_attributes: true
   # Recommended attributes to be promoted to labels.
   promote_resource_attributes:
     - service.instance.id


### PR DESCRIPTION
Prometheus config: activate `keep_identifying_resource_attributes` to ease usage of `target_info`
* Easier correlation with metrics that benefit of resource attribute promotion, traces, logs
* Easier usage in dashboards to populate values of parameter drop down lists