### PR TITLE
respect auth anonymous environment variable if set

### DIFF
--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -2,8 +2,10 @@
 
 source ./logging.sh
 
-export GF_AUTH_ANONYMOUS_ENABLED=true
-export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+if [ -z "${GF_AUTH_ANONYMOUS_ENABLED}" ]; then
+  export GF_AUTH_ANONYMOUS_ENABLED=true
+  export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+fi
 
 export GF_PATHS_HOME=/data/grafana
 export GF_PATHS_DATA=/data/grafana/data

--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -4,7 +4,7 @@ source ./logging.sh
 
 if [ -z "${GF_AUTH_ANONYMOUS_ENABLED}" ]; then
      export GF_AUTH_ANONYMOUS_ENABLED=true
-  export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+     export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
 fi
 
 export GF_PATHS_HOME=/data/grafana

--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -3,7 +3,7 @@
 source ./logging.sh
 
 if [ -z "${GF_AUTH_ANONYMOUS_ENABLED}" ]; then
-     export GF_AUTH_ANONYMOUS_ENABLED=true
+	export GF_AUTH_ANONYMOUS_ENABLED=true
      export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
 fi
 

--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -4,7 +4,7 @@ source ./logging.sh
 
 if [ -z "${GF_AUTH_ANONYMOUS_ENABLED}" ]; then
 	export GF_AUTH_ANONYMOUS_ENABLED=true
-     export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+	export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
 fi
 
 export GF_PATHS_HOME=/data/grafana

--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -3,7 +3,7 @@
 source ./logging.sh
 
 if [ -z "${GF_AUTH_ANONYMOUS_ENABLED}" ]; then
-  export GF_AUTH_ANONYMOUS_ENABLED=true
+     export GF_AUTH_ANONYMOUS_ENABLED=true
   export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
 fi
 


### PR DESCRIPTION
Allow control of anonymous access by respecting the `GF_AUTH_ANONYMOUS_ENABLED` env variable when set. Default behavior remains unchanged when no variable is provided.

Related to issue https://github.com/grafana/docker-otel-lgtm/issues/232 & PR https://github.com/grafana/docker-otel-lgtm/pull/318