### PR TITLE
Fix run-grafana.sh env variable check

### DIFF
--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -2,7 +2,7 @@
 
 source ./logging.sh
 
-if [ -z "${GF_AUTH_ANONYMOUS_ENABLED}" ]; then
+if [[ -z "${GF_AUTH_ANONYMOUS_ENABLED}" ]]; then
 	export GF_AUTH_ANONYMOUS_ENABLED=true
 	export GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
 fi


### PR DESCRIPTION
https://github.com/grafana/docker-otel-lgtm/pull/358 introduced a bug as the `if` statement is using single brackets.

This would usually work but apparently in this docker environment the shell is treating an unset variable as an error when you reference it. This behaviour is likely caused by the `set -u` or `set -o nounset` option.

The result is this error message and then Grafana never starting up

```
./run-grafana.sh: line 5: GF_AUTH_ANONYMOUS_ENABLED: unbound variable
```

Using double brackets we avoid this issue and Grafana runs properly whether or not `GF_AUTH_ANONYMOUS_ENABLED` is set.

https://github.com/grafana/docker-otel-lgtm/issues/363