### PR TITLE
check if OTEL_EXPORTER_* variables are both set AND not empty

### DIFF
--- a/docker/run-otelcol.sh
+++ b/docker/run-otelcol.sh
@@ -4,11 +4,11 @@ source ./logging.sh
 
 secondary_config_file=""
 
-if [[ -v OTEL_EXPORTER_OTLP_ENDPOINT ]]; then
+if [[ -n OTEL_EXPORTER_OTLP_ENDPOINT ]]; then
 	echo "Also enabling OTLP/HTTP export to ${OTEL_EXPORTER_OTLP_ENDPOINT}"
 	secondary_config_file="--config=file:./otelcol-config-export-http.yaml"
 
-	if [[ -v OTEL_EXPORTER_OTLP_HEADERS ]]; then
+	if [[ -n OTEL_EXPORTER_OTLP_HEADERS ]]; then
 		echo "Adding headers from OTEL_EXPORTER_OTLP_HEADERS"
 
 		yaml_headers="{"

--- a/docker/run-otelcol.sh
+++ b/docker/run-otelcol.sh
@@ -4,11 +4,11 @@ source ./logging.sh
 
 secondary_config_file=""
 
-if [[ -n OTEL_EXPORTER_OTLP_ENDPOINT ]]; then
+if [[ -n ${OTEL_EXPORTER_OTLP_ENDPOINT} ]]; then
 	echo "Also enabling OTLP/HTTP export to ${OTEL_EXPORTER_OTLP_ENDPOINT}"
 	secondary_config_file="--config=file:./otelcol-config-export-http.yaml"
 
-	if [[ -n OTEL_EXPORTER_OTLP_HEADERS ]]; then
+	if [[ -n ${OTEL_EXPORTER_OTLP_HEADERS} ]]; then
 		echo "Adding headers from OTEL_EXPORTER_OTLP_HEADERS"
 
 		yaml_headers="{"


### PR DESCRIPTION
Updates `docker/run-otelcol.sh` to check if the OTEL_EXPORTER_* environment variables are both present and not empty.

Fixes #421 