### PR TITLE
fix ebpf example

### DIFF
--- a/examples/ebpf-profiler/.oatsignore
+++ b/examples/ebpf-profiler/.oatsignore
@@ -1,1 +1,0 @@
-Test is flaky

--- a/examples/ebpf-profiler/Dockerfile
+++ b/examples/ebpf-profiler/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04 AS builder
 
 ENV GO_VERSION=1.24.3
-ARG VERSION=4377c7485ec426eb1210098593e6175d2d53bcd8
+ARG VERSION=009a07f3803c33374eba0715ccae98dbfde7e225
 
 RUN apt-get update && apt-get -y install wget gcc
 RUN wget https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz

--- a/examples/ebpf-profiler/README.md
+++ b/examples/ebpf-profiler/README.md
@@ -31,8 +31,13 @@ docker compose down
 
 2. Access the UI:
 
-Navigate to the [Pyroscope UI](http://localhost:3000/a/grafana-pyroscope-app/explore?searchText=&panelType=time-series&layout=grid&hideNoData=off&explorationType=flame-graph&var-serviceName=unknown&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds&var-spanSelector=undefined&var-dataSource=pyroscope&var-filters=&var-filtersBaseline=&var-filtersComparison=&var-groupBy=all&maxNodes=16384) to visualize the profiles.
+Navigate to the [Pyroscope UI][Pyroscope UI] to visualize the profiles.
 
 ## Example output
 
 ![Image](https://github.com/user-attachments/assets/15ff58d4-218a-43dd-9835-df12e13ced3f)
+
+<!-- editorconfig-checker-disable -->
+<!-- markdownlint-disable MD013 -->
+
+[Pyroscope UI]: http://localhost:3000/a/grafana-pyroscope-app/explore?searchText=&panelType=time-series&layout=grid&hideNoData=off&explorationType=flame-graph&var-serviceName=unknown&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds&var-spanSelector=undefined&var-dataSource=pyroscope&var-filters=&var-filtersBaseline=&var-filtersComparison=&var-groupBy=all&maxNodes=16384

--- a/examples/ebpf-profiler/README.md
+++ b/examples/ebpf-profiler/README.md
@@ -23,7 +23,7 @@ These examples demonstrate:
 
 ```bash
 # Start all services
-docker compose up --build
+docker compose up --remove-orphans --build
 
 # To clean up
 docker compose down

--- a/examples/ebpf-profiler/README.md
+++ b/examples/ebpf-profiler/README.md
@@ -6,7 +6,8 @@ This example is based on the latest Git commit - releases no not yet exist.
 
 **⚠️ Important: Linux-only Support**
 This example can only be run on Linux systems (amd64/arm64) as it relies on eBPF technology which is
-specific to the Linux kernel. The profiler requires privileged access to system resources.
+specific to the Linux kernel. 
+The profiler requires privileged access to system resources.
 For more details refer to the OpenTelemetry ebpf profiler
 [docs](https://github.com/open-telemetry/opentelemetry-ebpf-profiler).
 

--- a/examples/ebpf-profiler/README.md
+++ b/examples/ebpf-profiler/README.md
@@ -31,10 +31,7 @@ docker compose down
 
 2. Access the UI:
 
-```bash
-# Access Grafana
-http://localhost:3000
-```
+Navigate to the [Pyroscope UI](http://localhost:3000/a/grafana-pyroscope-app/explore?searchText=&panelType=time-series&layout=grid&hideNoData=off&explorationType=flame-graph&var-serviceName=unknown&var-profileMetricId=process_cpu:cpu:nanoseconds:cpu:nanoseconds&var-spanSelector=undefined&var-dataSource=pyroscope&var-filters=&var-filtersBaseline=&var-filtersComparison=&var-groupBy=all&maxNodes=16384) to visualize the profiles.
 
 ## Example output
 

--- a/examples/ebpf-profiler/README.md
+++ b/examples/ebpf-profiler/README.md
@@ -6,7 +6,7 @@ This example is based on the latest Git commit - releases no not yet exist.
 
 **⚠️ Important: Linux-only Support**
 This example can only be run on Linux systems (amd64/arm64) as it relies on eBPF technology which is
-specific to the Linux kernel. 
+specific to the Linux kernel.
 The profiler requires privileged access to system resources.
 For more details refer to the OpenTelemetry ebpf profiler
 [docs](https://github.com/open-telemetry/opentelemetry-ebpf-profiler).

--- a/examples/ebpf-profiler/docker-compose.oats.yml
+++ b/examples/ebpf-profiler/docker-compose.oats.yml
@@ -24,32 +24,32 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
     ports:
-      - "8081:8081"
+      - "8080:8081"
     depends_on:
       - lgtm
-
-  java:
-    build:
-      context: ../java
-      dockerfile: ../java/json-logging-otlp/Dockerfile
-    environment:
-      OTEL_SERVICE_NAME: "rolldice"
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
-      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
-    ports:
-      - "8080:8080"
-    depends_on:
-      - lgtm
-
-  python:
-    build:
-      context: ../python
-      dockerfile: ../python/Dockerfile
-    environment:
-      OTEL_SERVICE_NAME: "rolldice"
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
-      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
-    ports:
-      - "8082:8082"
-    depends_on:
-      - lgtm
+#
+#  java:
+#    build:
+#      context: ../java
+#      dockerfile: ../java/json-logging-otlp/Dockerfile
+#    environment:
+#      OTEL_SERVICE_NAME: "rolldice"
+#      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
+#      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+#    ports:
+#      - "8080:8080"
+#    depends_on:
+#      - lgtm
+#
+#  python:
+#    build:
+#      context: ../python
+#      dockerfile: ../python/Dockerfile
+#    environment:
+#      OTEL_SERVICE_NAME: "rolldice"
+#      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
+#      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+#    ports:
+#      - "8082:8082"
+#    depends_on:
+#      - lgtm

--- a/examples/ebpf-profiler/docker-compose.oats.yml
+++ b/examples/ebpf-profiler/docker-compose.oats.yml
@@ -14,14 +14,17 @@ services:
     depends_on:
       - lgtm
 
-  python:
+  # instrumented applications - sorted alphabetically by language
+  go:
     build:
-      context: ../python
-      dockerfile: ../python/Dockerfile
+      context: ../go
+      dockerfile: ../go/Dockerfile
     environment:
       OTEL_SERVICE_NAME: "rolldice"
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+    ports:
+      - "8081:8081"
     depends_on:
       - lgtm
 
@@ -33,5 +36,20 @@ services:
       OTEL_SERVICE_NAME: "rolldice"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+    ports:
+      - "8080:8080"
+    depends_on:
+      - lgtm
+
+  python:
+    build:
+      context: ../python
+      dockerfile: ../python/Dockerfile
+    environment:
+      OTEL_SERVICE_NAME: "rolldice"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
+      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+    ports:
+      - "8082:8082"
     depends_on:
       - lgtm

--- a/examples/ebpf-profiler/docker-compose.yml
+++ b/examples/ebpf-profiler/docker-compose.yml
@@ -12,27 +12,8 @@ services:
       - "4318:4318"
 
   generate-traffic:
-#    image: ubuntu:24.04
     build:
       dockerfile: generate-traffic.Dockerfile
-#    command:
-#      - "/bin/bash"
-#      - "-c"
-#      - >
-#        watch 'curl -s http://java:8080/rolldice;
-#        curl -s http://go:8081/rolldice;
-#        curl -s http://python:8082/rolldice;
-#        curl -s http://dotnet:8083/rolldice;
-#        curl -s http://nodejs:8084/rolldice?rolls=5'
-#      - 'wget -q http://java:8080/rolldice -O /dev/null || echo "error reaching java service"'
-#      - >
-#        'while true; do
-#        wget -q http://java:8080/rolldice -O /dev/null || echo "error reaching java service";
-#        wget -q http://go:8081/rolldice -O /dev/null || echo "error reaching go service";
-#        wget -q http://python:8082/rolldice -O /dev/null || echo "error reaching python service";
-#        wget -q http://dotnet:8083/rolldice -O /dev/null || echo "error reaching dotnet service";
-#        wget -q http://nodejs:8084/rolldice -O /dev/null || echo "error reaching nodejs service";
-#        sleep 1; done'
     networks:
       - otel-net
     depends_on:

--- a/examples/ebpf-profiler/docker-compose.yml
+++ b/examples/ebpf-profiler/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     command:
       - '/bin/sh'
       - '-c'
-      - 'while true; do wget -nc -q http://java:8080/rolldice > /dev/null; wget -nc -q http://python:8081/rolldice; wget -nc -q http://python:8082/rolldice; wget -nc -q http://python:8083/rolldice; wget -nc -q http://python:8084/rolldice > /dev/null; sleep 1; done'
+      - 'while true; do wget -nc -q http://java:8080/rolldice > /dev/null; wget -nc -q http://go:8081/rolldice; wget -nc -q http://python:8082/rolldice; wget -nc -q http://dotnet:8083/rolldice; wget -nc -q http://nodejs:8084/rolldice > /dev/null; sleep 1; done'
     networks:
       - otel-net
     depends_on:

--- a/examples/ebpf-profiler/docker-compose.yml
+++ b/examples/ebpf-profiler/docker-compose.yml
@@ -12,11 +12,27 @@ services:
       - "4318:4318"
 
   generate-traffic:
-    image: alpine
-    command:
-      - '/bin/sh'
-      - '-c'
-      - 'while true; do wget -nc -q http://java:8080/rolldice > /dev/null; wget -nc -q http://go:8081/rolldice; wget -nc -q http://python:8082/rolldice; wget -nc -q http://dotnet:8083/rolldice; wget -nc -q http://nodejs:8084/rolldice > /dev/null; sleep 1; done'
+#    image: ubuntu:24.04
+    build:
+      dockerfile: generate-traffic.Dockerfile
+#    command:
+#      - "/bin/bash"
+#      - "-c"
+#      - >
+#        watch 'curl -s http://java:8080/rolldice;
+#        curl -s http://go:8081/rolldice;
+#        curl -s http://python:8082/rolldice;
+#        curl -s http://dotnet:8083/rolldice;
+#        curl -s http://nodejs:8084/rolldice?rolls=5'
+#      - 'wget -q http://java:8080/rolldice -O /dev/null || echo "error reaching java service"'
+#      - >
+#        'while true; do
+#        wget -q http://java:8080/rolldice -O /dev/null || echo "error reaching java service";
+#        wget -q http://go:8081/rolldice -O /dev/null || echo "error reaching go service";
+#        wget -q http://python:8082/rolldice -O /dev/null || echo "error reaching python service";
+#        wget -q http://dotnet:8083/rolldice -O /dev/null || echo "error reaching dotnet service";
+#        wget -q http://nodejs:8084/rolldice -O /dev/null || echo "error reaching nodejs service";
+#        sleep 1; done'
     networks:
       - otel-net
     depends_on:

--- a/examples/ebpf-profiler/docker-compose.yml
+++ b/examples/ebpf-profiler/docker-compose.yml
@@ -40,17 +40,18 @@ services:
     depends_on:
       - lgtm
 
-  java:
+  # instrumented applications - sorted alphabetically by language
+
+  dotnet:
     build:
-      context: ../java
-      dockerfile: ../java/Dockerfile
+      context: ../dotnet
+      dockerfile: ../dotnet/Dockerfile
     environment:
       OTEL_SERVICE_NAME: "rolldice"
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
-      GRAFANA_ROLL_WAIT: "2000" # 2 seconds
     ports:
-      - "8080:8080"
+      - "8083:8083"
     networks:
       - otel-net
     depends_on:
@@ -71,31 +72,17 @@ services:
     depends_on:
       - lgtm
 
-  python:
+  java:
     build:
-      context: ../python
-      dockerfile: ../python/Dockerfile
+      context: ../java
+      dockerfile: ../java/Dockerfile
     environment:
       OTEL_SERVICE_NAME: "rolldice"
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+      GRAFANA_ROLL_WAIT: "2000" # 2 seconds
     ports:
-      - "8082:8082"
-    networks:
-      - otel-net
-    depends_on:
-      - lgtm
-
-  dotnet:
-    build:
-      context: ../dotnet
-      dockerfile: ../dotnet/Dockerfile
-    environment:
-      OTEL_SERVICE_NAME: "rolldice"
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
-      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
-    ports:
-      - "8083:8083"
+      - "8080:8080"
     networks:
       - otel-net
     depends_on:
@@ -111,6 +98,21 @@ services:
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
     ports:
       - "8084:8084"
+    networks:
+      - otel-net
+    depends_on:
+      - lgtm
+
+  python:
+    build:
+      context: ../python
+      dockerfile: ../python/Dockerfile
+    environment:
+      OTEL_SERVICE_NAME: "rolldice"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
+      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+    ports:
+      - "8082:8082"
     networks:
       - otel-net
     depends_on:

--- a/examples/ebpf-profiler/docker-compose.yml
+++ b/examples/ebpf-profiler/docker-compose.yml
@@ -16,12 +16,15 @@ services:
     command:
       - '/bin/sh'
       - '-c'
-      - 'while true; do wget -nc -q http://java:8080/rolldice > /dev/null; wget -nc -q http://python:8082/rolldice > /dev/null; sleep 1; done'
+      - 'while true; do wget -nc -q http://java:8080/rolldice > /dev/null; wget -nc -q http://python:8081/rolldice; wget -nc -q http://python:8082/rolldice; wget -nc -q http://python:8083/rolldice; wget -nc -q http://python:8084/rolldice > /dev/null; sleep 1; done'
     networks:
       - otel-net
     depends_on:
       - java
       - python
+      - dotnet
+      - go
+      - nodejs
 
   otel-ebpf-profiler:
     build:
@@ -35,6 +38,37 @@ services:
       - /sys/kernel/debug:/sys/kernel/debug
       - /sys/fs/cgroup:/sys/fs/cgroup
       - /proc:/proc
+    networks:
+      - otel-net
+    depends_on:
+      - lgtm
+
+  java:
+    build:
+      context: ../java
+      dockerfile: ../java/Dockerfile
+    environment:
+      OTEL_SERVICE_NAME: "rolldice"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
+      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+      GRAFANA_ROLL_WAIT: "2000" # 2 seconds
+    ports:
+      - "8080:8080"
+    networks:
+      - otel-net
+    depends_on:
+      - lgtm
+
+  go:
+    build:
+      context: ../go
+      dockerfile: ../go/Dockerfile
+    environment:
+      OTEL_SERVICE_NAME: "rolldice"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
+      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+    ports:
+      - "8081:8081"
     networks:
       - otel-net
     depends_on:
@@ -55,17 +89,31 @@ services:
     depends_on:
       - lgtm
 
-  java:
+  dotnet:
     build:
-      context: ../java
-      dockerfile: ../java/Dockerfile
+      context: ../dotnet
+      dockerfile: ../dotnet/Dockerfile
+    environment:
+      OTEL_SERVICE_NAME: "rolldice"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
+      OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+    ports:
+      - "8083:8083"
+    networks:
+      - otel-net
+    depends_on:
+      - lgtm
+
+  nodejs:
+    build:
+      context: ../nodejs
+      dockerfile: ../nodejs/Dockerfile
     environment:
       OTEL_SERVICE_NAME: "rolldice"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
-      GRAFANA_ROLL_WAIT: "2000" # 2 seconds
     ports:
-      - "8080:8080"
+      - "8084:8084"
     networks:
       - otel-net
     depends_on:

--- a/examples/ebpf-profiler/docker-compose.yml
+++ b/examples/ebpf-profiler/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - "4317:4317"
       - "4318:4318"
 
+  generate-traffic:
+    image: ubuntu:24.04
+    command:
+      - /bin/sh -c "watch 'curl -s http://localhost:8080/rolldice; curl -s http://localhost:8082/rolldice'"
+
   otel-ebpf-profiler:
     build:
       context: .
@@ -44,11 +49,12 @@ services:
   java:
     build:
       context: ../java
-      dockerfile: ../java/json-logging-otlp/Dockerfile
+      dockerfile: ../java/Dockerfile
     environment:
       OTEL_SERVICE_NAME: "rolldice"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+      GRAFANA_ROLL_WAIT: "2000" # 2 seconds
     networks:
       - otel-net
     depends_on:

--- a/examples/ebpf-profiler/docker-compose.yml
+++ b/examples/ebpf-profiler/docker-compose.yml
@@ -12,9 +12,16 @@ services:
       - "4318:4318"
 
   generate-traffic:
-    image: ubuntu:24.04
+    image: alpine
     command:
-      - /bin/sh -c "watch 'curl -s http://localhost:8080/rolldice; curl -s http://localhost:8082/rolldice'"
+      - '/bin/sh'
+      - '-c'
+      - 'while true; do wget -nc -q http://java:8080/rolldice > /dev/null; wget -nc -q http://python:8082/rolldice > /dev/null; sleep 1; done'
+    networks:
+      - otel-net
+    depends_on:
+      - java
+      - python
 
   otel-ebpf-profiler:
     build:
@@ -41,6 +48,8 @@ services:
       OTEL_SERVICE_NAME: "rolldice"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
+    ports:
+      - "8082:8082"
     networks:
       - otel-net
     depends_on:
@@ -55,6 +64,8 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't have to wait 60s for metrics
       GRAFANA_ROLL_WAIT: "2000" # 2 seconds
+    ports:
+      - "8080:8080"
     networks:
       - otel-net
     depends_on:

--- a/examples/ebpf-profiler/generate-traffic.Dockerfile
+++ b/examples/ebpf-profiler/generate-traffic.Dockerfile
@@ -2,5 +2,7 @@ FROM ubuntu:24.04
 
 COPY generate-traffic.sh /usr/local/bin/
 
+RUN apt-get update && apt-get -y install curl
+
 ENTRYPOINT ["/usr/local/bin/generate-traffic.sh"]
 

--- a/examples/ebpf-profiler/generate-traffic.Dockerfile
+++ b/examples/ebpf-profiler/generate-traffic.Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:24.04
+
+COPY generate-traffic.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/generate-traffic.sh"]
+

--- a/examples/ebpf-profiler/generate-traffic.sh
+++ b/examples/ebpf-profiler/generate-traffic.sh
@@ -1,7 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
-watch 'curl -s http://java:8080/rolldice; \
-  curl -s http://go:8081/rolldice; \
-  curl -s http://python:8082/rolldice; \
-  curl -s http://dotnet:8083/rolldice; \
-  curl -s http://nodejs:8084/rolldice?rolls=5'
+while true; do
+  curl -s http://java:8080/rolldice || echo "error reaching java service";
+  curl -s http://go:8081/rolldice || echo "error reaching go service";
+  curl -s http://python:8082/rolldice || echo "error reaching python service";
+  curl -s http://dotnet:8083/rolldice || echo "error reaching dotnet service";
+  curl -s http://nodejs:8084/rolldice?rolls=5 || echo "error reaching nodejs service";
+  sleep 1;
+done

--- a/examples/ebpf-profiler/generate-traffic.sh
+++ b/examples/ebpf-profiler/generate-traffic.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 while true; do
-  curl -s http://java:8080/rolldice || echo "error reaching java service";
-  curl -s http://go:8081/rolldice || echo "error reaching go service";
-  curl -s http://python:8082/rolldice || echo "error reaching python service";
-  curl -s http://dotnet:8083/rolldice || echo "error reaching dotnet service";
-  curl -s http://nodejs:8084/rolldice?rolls=5 || echo "error reaching nodejs service";
-  sleep 1;
+	curl -s http://java:8080/rolldice || echo "error reaching java service"
+	curl -s http://go:8081/rolldice || echo "error reaching go service"
+	curl -s http://python:8082/rolldice || echo "error reaching python service"
+	curl -s http://dotnet:8083/rolldice || echo "error reaching dotnet service"
+	curl -s http://nodejs:8084/rolldice?rolls=5 || echo "error reaching nodejs service"
+	sleep 1
 done

--- a/examples/ebpf-profiler/generate-traffic.sh
+++ b/examples/ebpf-profiler/generate-traffic.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+watch 'curl -s http://java:8080/rolldice; \
+  curl -s http://go:8081/rolldice; \
+  curl -s http://python:8082/rolldice; \
+  curl -s http://dotnet:8083/rolldice; \
+  curl -s http://nodejs:8084/rolldice?rolls=5'

--- a/examples/ebpf-profiler/oats.yaml
+++ b/examples/ebpf-profiler/oats.yaml
@@ -5,10 +5,15 @@ docker-compose:
     - ./docker-compose.oats.yml
 expected:
   profiles:
-    - query: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds{process_executable_name=~"python.*"}'
+    # go
+    - query: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds{process_executable_name=~"rolldice"}'
       flamebearers:
-        # not very useful, because the python function names are not in the flamegraph
-        contains: "python"
-    - query: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds{process_executable_name="java"}'
-      flamebearers:
-        contains: "void org.springframework.boot.SpringApplication.refreshContext(org.springframework.context.ConfigurableApplicationContext)"
+        contains: "main.rolldice"
+    # python and java are flaky
+#    - query: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds{process_executable_name=~"python.*"}'
+#      flamebearers:
+#        # not very useful, because the python function names are not in the flamegraph
+#        contains: "python"
+#    - query: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds{process_executable_name="java"}'
+#      flamebearers:
+#        contains: "void org.springframework.boot.SpringApplication.refreshContext(org.springframework.context.ConfigurableApplicationContext)"

--- a/examples/ebpf-profiler/oats.yaml
+++ b/examples/ebpf-profiler/oats.yaml
@@ -3,6 +3,8 @@
 docker-compose:
   files:
     - ./docker-compose.oats.yml
+input:
+  - path: /rolldice
 expected:
   profiles:
     # go

--- a/examples/go/rolldice.go
+++ b/examples/go/rolldice.go
@@ -7,14 +7,14 @@ import (
 	"math/rand"
 	"net/http"
 	"strconv"
+	"time"
 )
 
 func rolldice(w http.ResponseWriter, r *http.Request) {
 	ctx, span := tracer.Start(r.Context(), "roll")
 	defer span.End()
 
-	//nolint:gosec
-	roll := 1 + rand.Intn(6)
+	roll := 1 + roll()
 
 	msg := fmt.Sprintf("Rolled a dice: %d\n", roll)
 	logger.InfoContext(ctx, msg, slog.Int("result", roll))
@@ -23,4 +23,16 @@ func rolldice(w http.ResponseWriter, r *http.Request) {
 	if _, err := io.WriteString(w, resp); err != nil {
 		logger.ErrorContext(ctx, "Write failed: %v\n", slog.Any("error", err))
 	}
+}
+
+func roll() int {
+	// simulate a long operation
+	// busy wait to make sure it's shown in the flame graph
+	start := time.Now()
+	for time.Since(start) < 1*time.Second {
+		// busy wait
+	}
+
+	//nolint:gosec
+	return rand.Intn(6)
 }

--- a/examples/java/Dockerfile
+++ b/examples/java/Dockerfile
@@ -1,0 +1,21 @@
+FROM ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.15.0 AS agent
+
+FROM eclipse-temurin:21.0.7_6-jdk AS builder
+
+WORKDIR /usr/src/app/
+
+COPY ./mvnw pom.xml ./
+COPY ./.mvn ./.mvn
+COPY ./src ./src
+RUN --mount=type=cache,target=/root/.m2 ./mvnw install -DskipTests
+
+FROM eclipse-temurin:21.0.7_6-jre
+
+WORKDIR /usr/src/app/
+
+COPY --from=agent --chown=cnb /javaagent.jar /app/javaagent.jar
+ENV JAVA_TOOL_OPTIONS=-javaagent:/app/javaagent.jar
+COPY --from=builder /usr/src/app/target/rolldice.jar ./app.jar
+
+EXPOSE 8080
+ENTRYPOINT [ "java", "-jar", "./app.jar" ]

--- a/examples/java/src/main/java/com/grafana/example/RollController.java
+++ b/examples/java/src/main/java/com/grafana/example/RollController.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,11 +15,16 @@ public class RollController {
 
   private static final Logger logger = LoggerFactory.getLogger(RollController.class);
   private final Random random = new Random(0);
+  private final float wait;
+
+  public RollController(@Value("${grafana.roll.wait:200}") float wait) {
+    this.wait = wait;
+  }
 
   /** Simulates rolling a dice. */
   @GetMapping("/rolldice")
   public String index(@RequestParam("player") Optional<String> player) throws InterruptedException {
-    Thread.sleep((long) (Math.abs((random.nextGaussian() + 1.0) * 200.0)));
+    veryLongCalculation();
     if (random.nextInt(10) < 3) {
       throw new RuntimeException("simulating an error");
     }
@@ -29,6 +35,10 @@ public class RollController {
       logger.info("Anonymous player is rolling the dice: {}", result);
     }
     return Integer.toString(result);
+  }
+
+  private void veryLongCalculation() throws InterruptedException {
+    Thread.sleep((long) (Math.abs((random.nextGaussian() + 1.0) * wait)));
   }
 
   private int getRandomNumber(int min, int max) {

--- a/examples/java/src/main/java/com/grafana/example/RollController.java
+++ b/examples/java/src/main/java/com/grafana/example/RollController.java
@@ -18,6 +18,7 @@ public class RollController {
   private final float wait;
 
   public RollController(@Value("${grafana.roll.wait:200}") float wait) {
+    logger.info("Wait time is set to {} ms", wait);
     this.wait = wait;
   }
 


### PR DESCRIPTION
eBPF profiler is really very alpha - method names are often not resolved and it's not clear (to me) why.

I hope that `go` now works as a reliable example 

- for the OATs test
- and to demonstrate (for a blog post) how to find a (deliberately) slow method

![image](https://github.com/user-attachments/assets/b34bd4fb-304d-4a68-8935-b4be3e6b5556)
