### PR TITLE
Add pyroscope volume to k8s Deployment

### DIFF
--- a/docker/pyroscope-config.yaml
+++ b/docker/pyroscope-config.yaml
@@ -18,3 +18,6 @@ ingester:
         store: inmemory
       replication_factor: 1
     min_ready_duration: 1s
+
+pyroscopedb:
+  data_path: "/data/pyroscope"

--- a/k8s/lgtm.yaml
+++ b/k8s/lgtm.yaml
@@ -61,6 +61,8 @@ spec:
               mountPath: /loki
             - name: p8s-storage
               mountPath: /data/prometheus
+            - name: pyroscope-storage
+              mountPath: /data/pyroscope
       volumes:
         - name: tempo-data
           emptyDir: {}
@@ -71,4 +73,6 @@ spec:
         - name: loki-storage
           emptyDir: {}
         - name: p8s-storage
+          emptyDir: {}
+        - name: pyroscope-storage
           emptyDir: {}


### PR DESCRIPTION
k8s logs show

```
Running Grafana v11.6.0 logging=false
Running Loki v3.4.3 logging=false
Running OpenTelemetry Collector v0.124.0 logging=false
Running Prometheus v3.2.1 logging=false
Waiting for the OpenTelemetry collector and the Grafana LGTM stack to start up...
Running Tempo v2.7.2 logging=false
mkdir: cannot create directory '/data/pyroscope': Permission denied
Prometheus is up and running. Startup time: 1 seconds
Loki is up and running. Startup time: 2 seconds
Tempo is up and running. Startup time: 2 seconds
OpenTelemetry collector is up and running. Startup time: 6 seconds
Grafana is up and running. Startup time: 27 seconds
```

And the pod is never in a Ready state