### PR TITLE
Allow CORS to the http endpoint

### DIFF
--- a/docker/otelcol-config.yaml
+++ b/docker/otelcol-config.yaml
@@ -5,6 +5,9 @@ receivers:
         endpoint: 0.0.0.0:4317
       http:
         endpoint: 0.0.0.0:4318
+        cors:
+          allowed_origins:
+            - http://*
   prometheus/collector:
     config:
       scrape_configs:


### PR DESCRIPTION
This pull request introduces a configuration update to the OpenTelemetry Collector to allow more flexible cross-origin resource sharing (CORS) settings. This is useful for testing Faro locally.

Configuration updates:

* [`docker/otelcol-config.yaml`](diffhunk://#diff-6db5e34a1aaf1f6abe4cbb9be70e8267e04d36057acf2a0d6fcc7d4435ea5e15R8-R10): Added a `cors` configuration under the `http` receiver to specify `allowed_origins` with a wildcard pattern (`http://*`). This change enables the OpenTelemetry Collector to accept requests from any HTTP origin.

Ref. https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md#server-configuration