### PR TITLE
Use upstream build image

### DIFF
--- a/examples/ebpf-profiler/Dockerfile
+++ b/examples/ebpf-profiler/Dockerfile
@@ -1,13 +1,11 @@
-FROM golang:1.24.3 AS builder
+FROM otel/opentelemetry-ebpf-profiler-dev:202503260641 AS builder
 
 ARG VERSION=009a07f3803c33374eba0715ccae98dbfde7e225
-
-RUN apt-get update && apt-get -y install wget gcc
 RUN wget https://github.com/open-telemetry/opentelemetry-ebpf-profiler/archive/$VERSION.tar.gz
 RUN mkdir /profiler
 RUN tar --strip-components=1 -C /profiler -xzf $VERSION.tar.gz
 WORKDIR /profiler
-RUN /usr/local/go/bin/go build .
+RUN /bin/bash -euo pipefail -c "source /etc/profile && make ebpf-profiler"
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
On closer look the profiler misses a few of the built in things that are part of the upstream project. Using their image and makefile target to build the binary.