### PR TITLE
Disable dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,6 @@
   branchPrefix: "grafanarenovatebot/",
   platformCommit: "enabled",
   automerge: true,
-  dependencyDashboard: true,
   ignorePaths: [],
   ignoreUnstable: true,
   packageRules: [


### PR DESCRIPTION
Renovate keeps creating new issues and spamming the repo.
