### PR TITLE
feat: allow pre-installing plugins using GF_PLUGINS_PREINSTALL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ development, demo, and testing environments and persisting data to an external v
 doesn't change that. However, this feature could be useful in certain cases for
 some users even in testing situations.
 
+### Pre-install Grafana plugins
+
+You can pre-install Grafana plugins by adding them to the `GF_PLUGINS_PREINSTALL` environment variable. See the [Grafana documentation][https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#install-plugins-in-the-docker-container] for more information.
+
 ## Run lgtm in Kubernetes
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ some users even in testing situations.
 
 ### Pre-install Grafana plugins
 
-You can pre-install Grafana plugins by adding them to the `GF_PLUGINS_PREINSTALL` environment variable. See the [Grafana documentation][https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#install-plugins-in-the-docker-container] for more information.
+You can pre-install Grafana plugins by adding them to the `GF_PLUGINS_PREINSTALL` environment variable. See the [Grafana documentation][grafana-preinstall-plugins] for more information.
 
 ## Run lgtm in Kubernetes
 
@@ -204,6 +204,7 @@ Each example uses a different application port
 
 [app-o11y]: https://grafana.com/products/cloud/application-observability/
 [examples]: https://github.com/grafana/docker-otel-lgtm/tree/main/examples
+[grafana-preinstall-plugins]: https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#install-plugins-in-the-docker-container
 [mise]: https://github.com/jdx/mise
 [mltp]: https://github.com/grafana/intro-to-mltp
 [otel-checker]: https://github.com/grafana/otel-checker/

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ some users even in testing situations.
 
 ### Pre-install Grafana plugins
 
-You can pre-install Grafana plugins by adding them to the `GF_PLUGINS_PREINSTALL` environment variable. See the [Grafana documentation][grafana-preinstall-plugins] for more information.
+You can pre-install Grafana plugins by adding them to the `GF_PLUGINS_PREINSTALL` environment variable.
+See the [Grafana documentation][grafana-preinstall-plugins] for more information.
 
 ## Run lgtm in Kubernetes
 

--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -13,7 +13,11 @@ export GF_PATHS_PLUGINS=/data/grafana/plugins
 
 # pyroscope settings:
 # profiles drilldown connects to this plugin automatically - so we install it (even though it does nothing)
-export GF_PLUGINS_PREINSTALL=grafana-llm-app
+if [ -n "${GF_PLUGINS_PREINSTALL:-}" ]; then
+    export GF_PLUGINS_PREINSTALL="${GF_PLUGINS_PREINSTALL},grafana-llm-app"
+else
+    export GF_PLUGINS_PREINSTALL=grafana-llm-app
+fi
 
 cd /otel-lgtm/grafana || exit 1
 run_with_logging "Grafana ${GRAFANA_VERSION}" "${ENABLE_LOGS_GRAFANA:-false}" ./bin/grafana server

--- a/docker/run-grafana.sh
+++ b/docker/run-grafana.sh
@@ -14,9 +14,9 @@ export GF_PATHS_PLUGINS=/data/grafana/plugins
 # pyroscope settings:
 # profiles drilldown connects to this plugin automatically - so we install it (even though it does nothing)
 if [ -n "${GF_PLUGINS_PREINSTALL:-}" ]; then
-    export GF_PLUGINS_PREINSTALL="${GF_PLUGINS_PREINSTALL},grafana-llm-app"
+	export GF_PLUGINS_PREINSTALL="${GF_PLUGINS_PREINSTALL},grafana-llm-app"
 else
-    export GF_PLUGINS_PREINSTALL=grafana-llm-app
+	export GF_PLUGINS_PREINSTALL=grafana-llm-app
 fi
 
 cd /otel-lgtm/grafana || exit 1


### PR DESCRIPTION
Fixes #638

Note: I have tried running all the linting and test scrips mentioned in the contributing guide, but they require `docker` which is not allowed on my work laptop (we use Podman and stuff), plus some images don't seem to support `arm64` architecture. But I believe the change is tiny and safe so that's probably okay.