### PR TITLE
Fix author exclusion

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -10,4 +10,5 @@ changelog:
         - "*"
       exclude:
         authors:
-          - grafanarenovatebot
+          - grafanarenovatebot[bot]
+          - renovatebot[bot]


### PR DESCRIPTION
Add `[bot]` suffix and add the renovate app for future user.
