### PR TITLE
Disable .NET major updates from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,12 @@
       matchPackageNames: ["grafana/shared-workflows"],
       versioning: "regex:^(?<compatibility>[a-z-]+)-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$",
     },
+    {
+      extends: ["monorepo:dotnet"],
+      description: ["Disable major version updates for .NET"],
+      matchUpdateTypes: ["major"],
+      enabled: false,
+    },
   ],
   vulnerabilityAlerts: {
     enabled: true,


### PR DESCRIPTION
Major updates will be done manually, plus stops pull requests for "go-live" release candidate images.

Context: #753
