### PR TITLE
Sign and attest GHCR image

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
+        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
         with:
           cosign-release: ${{ env.COSIGN_VERSION }}
 


### PR DESCRIPTION
Add steps to attest and sign the images pushed to GHCR with GitHub Attestations and Cosign.

Once merged and verified working, I'll migrate us from `build-push-to-dockerhub` to the new [`docker-build-push-image`](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image) action, then afterwards we should be able to sign the images pushed to Docker Hub too (see #850 and #851).
