### PR TITLE
Correct OTEL_EXPORTER_OTLP_ENDPOINT hostname in .NET example

### DIFF
--- a/examples/dotnet/docker-compose.yml
+++ b/examples/dotnet/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - 8083:8083
     environment:
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://lgtm:4318
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-lgtm:4318
       - OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
       - OTEL_METRIC_EXPORT_INTERVAL=5000 # so we don't have to wait 60s for metrics
     depends_on:


### PR DESCRIPTION
Adjusted incorrect hostname that was causing silent telemetry export failures