### PR TITLE
Migrate to docker-build-push-image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           context: docker
           push: true
           platforms: linux/amd64,linux/arm64
-          registries: 'dockerhub'
+          registries: "dockerhub"
           tags: |-
             type=match,pattern=v(.*),group=1
             latest


### PR DESCRIPTION
Migrate to the new [`docker-build-push-image` action](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image).
