### PR TITLE
Fix container labels

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -58,6 +58,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |-
             org.opencontainers.image.ref.name=${{ github.ref_name }}
+            org.opencontainers.image.revision=${{ github.sha }}
             vcs-ref=${{ github.sha }}
             version=${{ github.ref_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
             latest
           labels: |-
             org.opencontainers.image.ref.name=${{ github.ref_name }}
+            org.opencontainers.image.revision=${{ github.sha }}
             vcs-ref=${{ github.sha }}
             version=${{ github.ref_name }}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -124,6 +124,7 @@ LABEL url="https://github.com/grafana/docker-otel-lgtm"
 LABEL vendor="Grafana Labs"
 
 # Blank out labels inherited from the base image that we don't want
+LABEL build-date=""
 LABEL cpe=""
 LABEL io.buildah.version=""
 LABEL release=""


### PR DESCRIPTION
- Remove `build-date`, which is wrong, and rely on `org.opencontainers.image.created` instead.
- Specify `org.opencontainers.image.revision` as it is not always correct.

See https://github.com/grafana/docker-otel-lgtm/issues/837#issuecomment-3502975712.
