### PR TITLE
Add release publishing workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,5 @@
 ---
-name: publish-release
+name: Publish Release
 
 on:
   workflow_dispatch:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-1. Open the [publish-release workflow][publish-release]
+1. Open the [Publish Release workflow][publish-release]
 2. Click on the **Run workflow** button
 3. If required, enter a specific version number (e.g. `1.2.3`) in the version field. If left
    blank, the version will be auto-incremented to the next patch version based on the


### PR DESCRIPTION
Add a workflow that can be manually triggered to create a new GitHub release.

The next stage of the automation would be to create a separate workflow that runs on a schedule, and then triggers this workflow through the GitHub API if there are relevant changes that need to be released.

Contributes to #846.
