### PR TITLE
[Prometheus] More resource attribute promotion

### DIFF
--- a/docker/prometheus.yaml
+++ b/docker/prometheus.yaml
@@ -28,8 +28,8 @@ otlp:
     - postgresql.schema.name
     - postgresql.table.name
     - postgresql.index.name
-      - database # used by otelcol/receiver/mongodb
-      - kafka.cluster.alias
+    - database # used by otelcol/receiver/mongodb
+    - kafka.cluster.alias
 storage:
   tsdb:
     # A 10min time window is enough because it can easily absorb retries and network delays.


### PR DESCRIPTION
Promote more resource attributes:
* `host.name`: host monitoring
* `k8s.node.name`: K8s node oriented view when doing K8s monitoring
* `postgresql.*` resource attributes used by otelcol/receiver/postgresql
* `database`: resource attribute used by otelcol/receiver/mongodb
* `kafka.cluster.alias`: resource attribute used by otelcol/receiver/kafkametrics