### PR TITLE
enable dependency dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended", "customManagers:dockerfileVersions", "customManagers:githubActionsVersions"],
   branchPrefix: "grafanarenovatebot/",
-  dependencyDashboard: false,
+  dependencyDashboard: true,
   platformCommit: "enabled",
   automerge: true,
   ignorePaths: [],


### PR DESCRIPTION
I wanted to see why go isn't updated to the lastest - and then noticed that the dashboard is not enabled.