### PR TITLE
fix: add TARGETARCH fallback and update Grafana download API

### DIFF
--- a/docker/download-loki.sh
+++ b/docker/download-loki.sh
@@ -8,6 +8,24 @@ if [[ -z "${VERSION}" ]]; then
 	exit 1
 fi
 
+# Set TARGETARCH if not set (fallback for non-buildx builds)
+if [[ -z "${TARGETARCH}" ]]; then
+	ARCH=$(uname -m)
+	case "${ARCH}" in
+		x86_64)
+			TARGETARCH="amd64"
+			;;
+		aarch64|arm64)
+			TARGETARCH="arm64"
+			;;
+		*)
+			echo "Unsupported architecture: ${ARCH}"
+			exit 1
+			;;
+	esac
+	echo "TARGETARCH not set, detected: ${TARGETARCH}"
+fi
+
 ARCHIVE=loki-linux-"${TARGETARCH}".zip
 curl -sOL https://github.com/grafana/loki/releases/download/"${VERSION}"/SHA256SUMS
 curl -sOL https://github.com/grafana/loki/releases/download/"${VERSION}"/"${ARCHIVE}"

--- a/docker/download-otelcol.sh
+++ b/docker/download-otelcol.sh
@@ -8,6 +8,24 @@ if [[ -z "${VERSION}" ]]; then
 	exit 1
 fi
 
+# Set TARGETARCH if not set (fallback for non-buildx builds)
+if [[ -z "${TARGETARCH}" ]]; then
+	ARCH=$(uname -m)
+	case "${ARCH}" in
+		x86_64)
+			TARGETARCH="amd64"
+			;;
+		aarch64|arm64)
+			TARGETARCH="arm64"
+			;;
+		*)
+			echo "Unsupported architecture: ${ARCH}"
+			exit 1
+			;;
+	esac
+	echo "TARGETARCH not set, detected: ${TARGETARCH}"
+fi
+
 ARCHIVE=otelcol-contrib_"${VERSION:1}"_linux_"${TARGETARCH}".tar.gz
 URL=https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/"${VERSION}"/"${ARCHIVE}"
 curl -sOL "${URL}".sig

--- a/docker/download-prometheus.sh
+++ b/docker/download-prometheus.sh
@@ -8,6 +8,24 @@ if [[ -z "${VERSION}" ]]; then
 	exit 1
 fi
 
+# Set TARGETARCH if not set (fallback for non-buildx builds)
+if [[ -z "${TARGETARCH}" ]]; then
+	ARCH=$(uname -m)
+	case "${ARCH}" in
+		x86_64)
+			TARGETARCH="amd64"
+			;;
+		aarch64|arm64)
+			TARGETARCH="arm64"
+			;;
+		*)
+			echo "Unsupported architecture: ${ARCH}"
+			exit 1
+			;;
+	esac
+	echo "TARGETARCH not set, detected: ${TARGETARCH}"
+fi
+
 ARCHIVE=prometheus-"${VERSION:1}".linux-"${TARGETARCH}"
 curl -sOL https://github.com/prometheus/prometheus/releases/download/"${VERSION}"/sha256sums.txt
 curl -sOL https://github.com/prometheus/prometheus/releases/download/"${VERSION}"/"${ARCHIVE}".tar.gz

--- a/docker/download-pyroscope.sh
+++ b/docker/download-pyroscope.sh
@@ -8,6 +8,24 @@ if [[ -z "${VERSION}" ]]; then
 	exit 1
 fi
 
+# Set TARGETARCH if not set (fallback for non-buildx builds)
+if [[ -z "${TARGETARCH}" ]]; then
+	ARCH=$(uname -m)
+	case "${ARCH}" in
+		x86_64)
+			TARGETARCH="amd64"
+			;;
+		aarch64|arm64)
+			TARGETARCH="arm64"
+			;;
+		*)
+			echo "Unsupported architecture: ${ARCH}"
+			exit 1
+			;;
+	esac
+	echo "TARGETARCH not set, detected: ${TARGETARCH}"
+fi
+
 ARCHIVE=pyroscope_"${VERSION:1}"_linux_"${TARGETARCH}".tar.gz
 curl -sOL https://github.com/grafana/pyroscope/releases/download/"${VERSION}"/checksums.txt
 curl -sOL https://github.com/grafana/pyroscope/releases/download/"${VERSION}"/"${ARCHIVE}"

--- a/docker/download-tempo.sh
+++ b/docker/download-tempo.sh
@@ -8,6 +8,24 @@ if [[ -z "${VERSION}" ]]; then
 	exit 1
 fi
 
+# Set TARGETARCH if not set (fallback for non-buildx builds)
+if [[ -z "${TARGETARCH}" ]]; then
+	ARCH=$(uname -m)
+	case "${ARCH}" in
+		x86_64)
+			TARGETARCH="amd64"
+			;;
+		aarch64|arm64)
+			TARGETARCH="arm64"
+			;;
+		*)
+			echo "Unsupported architecture: ${ARCH}"
+			exit 1
+			;;
+	esac
+	echo "TARGETARCH not set, detected: ${TARGETARCH}"
+fi
+
 ARCHIVE=tempo_"${VERSION:1}"_linux_"${TARGETARCH}".tar.gz
 curl -sOL https://github.com/grafana/tempo/releases/download/"${VERSION}"/SHA256SUMS
 curl -sOL https://github.com/grafana/tempo/releases/download/"${VERSION}"/"${ARCHIVE}"


### PR DESCRIPTION
- Add architecture detection fallback for non-buildx builds
- TARGETARCH is now automatically detected using uname when not set
- Update Grafana download script to use new API response format
- The Grafana API now returns a different archive naming format
- Extract directory name dynamically from archive contents

This fixes the Docker build error when running without buildx.