### PR TITLE
Fix renovate labels for pyroscope

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -36,7 +36,7 @@
       ignoreUnstable: false,
     },
     {
-      matchPackageNames: ["grafana/grafana", "prometheus/prometheus", "grafana/loki", "grafana/tempo", "open-telemetry/opentelemetry-collector-releases"],
+      matchPackageNames: ["grafana/grafana", "grafana/loki", "grafana/pyroscope", "grafana/tempo", "open-telemetry/opentelemetry-collector-releases", "prometheus/prometheus"],
       labels: ["docker-dependency"],
     },
     {


### PR DESCRIPTION
- Label renovate PRs for pyroscope with `docker-dependency` so that they are included in the auto-generated release notes.
- Sort entries.
