### PR TITLE
Fix missing .NET updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
   platformCommit: "enabled",
   automerge: true,
   ignorePaths: [],
+  ignorePresets: [":ignoreModulesAndTests"],
   ignoreUnstable: true,
   packageRules: [
     {


### PR DESCRIPTION
Fix renovate not updating the .NET examples.

The latest .NET SDK release is 1.15, but we're still using 1.12:

https://github.com/grafana/docker-otel-lgtm/blob/f58fa610f30c46cf07ff1b9242a2e59293a19d37/examples/dotnet/rolldice.csproj#L10-L14

Post-merge, this should cause renovate to generate a PR to update the packages.