### PR TITLE
fix: improve super-linter grouping in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,7 +28,7 @@
       schedule: ["before 4am on monday"],
     },
     {
-      matchPackageNames: ["super-linter/super-linter", "ghcr.io/super-linter/super-linter"],
+      matchPackageNames: ["/^(ghcr.io/)?super-linter/super-linter$/"],
       groupName: "super-linter",
     },
     {


### PR DESCRIPTION
Update the super-linter package rule to use matchPackagePatterns with a regex that matches both the GitHub Action (super-linter/super-linter) and Docker image (ghcr.io/super-linter/super-linter) variants. This ensures both dependencies are grouped together in the same PR.

Also add explicit packageName to the mise.toml renovate annotation for clarity.