### PR TITLE
Fix publish-release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -72,6 +72,11 @@ jobs:
               $key = $parts[0]
               $value = $parts[1]
 
+              # Ignore the LGTM_VERSION variable since it represents the overall version, not a specific component
+              if ($key -eq "LGTM_VERSION") {
+                continue
+              }
+
               if ($key.EndsWith($suffix)) {
                 $result[$key.Substring(0, $key.Length - $suffix.Length)] = [System.Version]::new($value.TrimStart("v"))
               }

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ venv/
 opentelemetry-javaagent*.jar
 grafana-opentelemetry*.jar
 build/
-
+obj/


### PR DESCRIPTION
- Fix publish-release failing after changes from #1016.
- Ignore `obj` folder from .NET example compilation.
