### PR TITLE
Reduce renovate update frequency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,7 +40,7 @@
       matchPackageNames: ["renovate"],
       description: ["Only update renovate once a week"],
       schedule: ["before 6am on Monday"],
-    }
+    },
   ],
   vulnerabilityAlerts: {
     enabled: true,


### PR DESCRIPTION
Renovate is released continuously and generates a noisy amount of updates.

Given that the version of renovate here is different to our hosted version, they're out-of-sync anyway so there's no need to update it so aggressively.
