### PR TITLE
Update flint to v0.5.0 and adopt Renovate preset

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -1,4 +1,9 @@
 {
+  ".github/renovate.json5": {
+    "renovate-config-presets": [
+      "grafana/flint"
+    ]
+  },
   ".github/workflows/ghcr-image-build-and-publish.yml": {
     "regex": [
       "cosign"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended", "customManagers:dockerfileVersions", "customManagers:githubActionsVersions"],
+  extends: ["config:recommended", "customManagers:dockerfileVersions", "customManagers:githubActionsVersions", "github>grafana/flint"],
   branchPrefix: "grafanarenovatebot/",
   dependencyDashboard: true,
   platformCommit: "enabled",
@@ -36,11 +36,6 @@
       matchUpdateTypes: ["major"],
       enabled: false,
     },
-    {
-      matchPackageNames: ["renovate"],
-      description: ["Only update renovate once a week"],
-      schedule: ["before 6am on Monday"],
-    },
   ],
   vulnerabilityAlerts: {
     enabled: true,
@@ -50,22 +45,9 @@
   customManagers: [
     {
       customType: "regex",
-      description: "Update flint version in raw.githubusercontent.com URLs (pinned to SHA)",
-      managerFilePatterns: ["/^mise\\.toml$/"],
-      matchStrings: ["https://raw\\.githubusercontent\\.com/(?<depName>[^/]+/[^/]+)/(?<currentDigest>[a-f0-9]{40})/.*#\\s*(?<currentValue>v\\S+)"],
-      datasourceTemplate: "github-tags",
-    },
-    {
-      customType: "regex",
       description: "Update _version variables in run.sh",
       managerFilePatterns: ["/run.sh$/"],
       matchStrings: ["# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_version=(?<currentValue>.+?)\\s"],
-    },
-    {
-      customType: "regex",
-      description: "Update _VERSION variables in mise.toml",
-      managerFilePatterns: ["/^mise\\.toml$/"],
-      matchStrings: ['# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_VERSION="?(?<currentValue>[^@"]+?)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"?\\s'],
     },
   ],
 }

--- a/mise.toml
+++ b/mise.toml
@@ -16,13 +16,13 @@ SUPER_LINTER_VERSION="v8.4.0@sha256:c5e3307932203ff9e1e8acfe7e92e894add6266605b5
 # Shared lint tasks from flint (https://github.com/grafana/flint)
 [tasks."lint:super-linter"]
 description = "Run Super-Linter on the repository"
-file = "https://raw.githubusercontent.com/grafana/flint/d51085d44d29d60914eaf1d353a45a68bfccf352/tasks/lint/super-linter.sh" # v0.2.0
+file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/super-linter.sh" # v0.5.0
 [tasks."lint:links"]
 description = "Check for broken links in changed files + all local links"
-file = "https://raw.githubusercontent.com/grafana/flint/d51085d44d29d60914eaf1d353a45a68bfccf352/tasks/lint/links.sh" # v0.2.0
+file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/links.sh" # v0.5.0
 [tasks."lint:renovate-deps"]
 description = "Verify renovate-tracked-deps.json is up to date"
-file = "https://raw.githubusercontent.com/grafana/flint/d51085d44d29d60914eaf1d353a45a68bfccf352/tasks/lint/renovate-deps.py" # v0.2.0
+file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/renovate-deps.py" # v0.5.0
 
 [tasks."lint"]
 description = "Run all lints"


### PR DESCRIPTION
## Summary
- Update [flint](https://github.com/grafana/flint) task URLs from v0.2.0 to v0.5.0
- Adopt the `github>grafana/flint` Renovate shareable preset, removing duplicated custom managers and package rules now provided by the preset

## Test plan
- [x] `mise run lint` passes locally