### PR TITLE
chore(deps): update dependency grafana/flint to v0.6.0

### DIFF
--- a/.github/config/lychee.toml
+++ b/.github/config/lychee.toml
@@ -9,11 +9,6 @@ max_concurrency = 4
 # Check link anchors
 include_fragments = true
 
-remap = [
-  # workaround for https://github.com/lycheeverse/lychee/issues/1729
-  "https://github.com/(.*?)/(.*?)/blob/(.*?)/(.*#.*)$ https://raw.githubusercontent.com/$1/$2/$3/$4"
-]
-
 exclude = [
   # locally running Grafana instance, used for testing and development
   "http://127.0.0.1:3000/",

--- a/mise.toml
+++ b/mise.toml
@@ -16,13 +16,13 @@ SUPER_LINTER_VERSION="v8.4.0@sha256:c5e3307932203ff9e1e8acfe7e92e894add6266605b5
 # Shared lint tasks from flint (https://github.com/grafana/flint)
 [tasks."lint:super-linter"]
 description = "Run Super-Linter on the repository"
-file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/super-linter.sh" # v0.5.0
+file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/super-linter.sh" # v0.6.0
 [tasks."lint:links"]
 description = "Check for broken links in changed files + all local links"
-file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/links.sh" # v0.5.0
+file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/links.sh" # v0.6.0
 [tasks."lint:renovate-deps"]
 description = "Verify renovate-tracked-deps.json is up to date"
-file = "https://raw.githubusercontent.com/grafana/flint/79215390bdc8aa92f2c01e350062aa4bbbbf1858/tasks/lint/renovate-deps.py" # v0.5.0
+file = "https://raw.githubusercontent.com/grafana/flint/5bb3726cfe3305072457c0c4fa85dce5ca154680/tasks/lint/renovate-deps.py" # v0.6.0
 
 [tasks."lint"]
 description = "Run all lints"


### PR DESCRIPTION
## Summary
- Update flint from v0.5.0 to v0.6.0
- Remove lychee `remap` workaround for [lychee#1729](https://github.com/lycheeverse/lychee/issues/1729) — flint v0.6.0 now handles GitHub fragment URL remaps natively in `links.sh`

## Test plan
- [ ] CI lint checks pass with updated flint tasks
- [ ] Link checking works correctly without the local remap rule