### PR TITLE
Fix renovate updates for OBI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,7 @@
       ignoreUnstable: false,
     },
     {
-      matchPackageNames: ["otel/ebpf-instrument", "grafana/grafana", "grafana/loki", "grafana/pyroscope", "grafana/tempo", "open-telemetry/opentelemetry-collector-releases", "prometheus/prometheus"],
+      matchPackageNames: ["grafana/grafana", "grafana/loki", "grafana/pyroscope", "grafana/tempo", "open-telemetry/opentelemetry-collector-releases", "open-telemetry/opentelemetry-ebpf-instrumentation", "prometheus/prometheus"],
       labels: ["docker-dependency"],
     },
     {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ ARG LOKI_VERSION=v3.6.7
 ARG PYROSCOPE_VERSION=v1.18.1
 # renovate: datasource=github-releases depName=opentelemetry-collector packageName=open-telemetry/opentelemetry-collector-releases
 ARG OPENTELEMETRY_COLLECTOR_VERSION=v0.146.1
-# renovate: datasource=docker depName=obi packageName=otel/ebpf-instrument
+# renovate: datasource=github-releases depName=obi packageName=open-telemetry/opentelemetry-ebpf-instrumentation
 ARG OBI_VERSION=v0.4.1
 
 # hadolint global ignore=DL3059


### PR DESCRIPTION
Track the releases, rather than the Docker image, so that the version is updated without the container digest like we use for the other components.

See #1093.
