### PR TITLE
Changed `otlphttp` to `otlp_http` in otel-config.yaml due to deprecation of the old name

### DIFF
--- a/docker/otelcol-config.yaml
+++ b/docker/otelcol-config.yaml
@@ -25,15 +25,15 @@ processors:
   batch:
 
 exporters:
-  otlphttp/metrics:
+  otlp_http/metrics:
     endpoint: http://127.0.0.1:9090/api/v1/otlp
     tls:
       insecure: true
-  otlphttp/traces:
+  otlp_http/traces:
     endpoint: http://127.0.0.1:4418
     tls:
       insecure: true
-  otlphttp/logs:
+  otlp_http/logs:
     endpoint: http://127.0.0.1:3100/otlp
     tls:
       insecure: true
@@ -54,18 +54,18 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlphttp/traces]
-      #exporters: [otlphttp/traces,debug/traces]
+      exporters: [otlp_http/traces]
+      #exporters: [otlp_http/traces,debug/traces]
     metrics:
       receivers: [otlp, prometheus/collector]
       processors: [batch]
-      exporters: [otlphttp/metrics]
-      #exporters: [otlphttp/metrics,debug/metrics]
+      exporters: [otlp_http/metrics]
+      #exporters: [otlp_http/metrics,debug/metrics]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [otlphttp/logs]
-      #exporters: [otlphttp/logs,debug/logs]
+      exporters: [otlp_http/logs]
+      #exporters: [otlp_http/logs,debug/logs]
     profiles:
       receivers: [otlp]
       exporters: [otlp/profiles]


### PR DESCRIPTION
Cf. https://github.com/open-telemetry/opentelemetry-collector/pull/14397 and it's documented in the [README.md](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/otlphttpexporter/README.md) of the HTTP exporter.

Note: with the old name it still works, but some warnings get logged.