### PR TITLE
Ignore otel/ebpf-instrument updates

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -26,6 +26,7 @@
   },
   "docker/Dockerfile": {
     "dockerfile": [
+      "docker.io/otel/ebpf-instrument",
       "docker.io/redhat/ubi9",
       "docker.io/redhat/ubi9-micro"
     ],

--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -26,7 +26,6 @@
   },
   "docker/Dockerfile": {
     "dockerfile": [
-      "docker.io/otel/ebpf-instrument",
       "docker.io/redhat/ubi9",
       "docker.io/redhat/ubi9-micro"
     ],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,8 +28,9 @@
     },
     {
       // version is derived from OBI_VERSION which tracks open-telemetry/opentelemetry-ebpf-instrumentation
+      matchDatasources: ["docker"],
       matchPackageNames: ["otel/ebpf-instrument"],
-      enabled: false,
+      ignoreDeps: ["otel/ebpf-instrument"],
     },
     {
       matchPackageNames: ["grafana/shared-workflows"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,8 +29,8 @@
     {
       // version is derived from OBI_VERSION which tracks open-telemetry/opentelemetry-ebpf-instrumentation
       matchDatasources: ["docker"],
-      matchPackageNames: ["otel/ebpf-instrument"],
-      ignoreDeps: ["otel/ebpf-instrument"],
+      matchPackageNames: ["docker.io/otel/ebpf-instrument"],
+      ignoreDeps: ["docker.io/otel/ebpf-instrument"],
     },
     {
       matchPackageNames: ["grafana/shared-workflows"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,7 @@
       // version is derived from OBI_VERSION which tracks open-telemetry/opentelemetry-ebpf-instrumentation
       matchDatasources: ["docker"],
       matchPackageNames: ["docker.io/otel/ebpf-instrument"],
-      ignoreDeps: ["docker.io/otel/ebpf-instrument"],
+      enabled: false,
     },
     {
       matchPackageNames: ["grafana/shared-workflows"],


### PR DESCRIPTION
Ignore otel/ebpf-instrument to avoid duplicated renovate PRs to update OBI (e.g. #1258).
