### PR TITLE
Attempt to fix OTEL startup

### DIFF
--- a/docker/run-otelcol.bats
+++ b/docker/run-otelcol.bats
@@ -71,7 +71,7 @@ run_otelcol() {
 @test "debug only: overlay has no external exporters" {
 	export OTEL_COLLECTOR_DEBUG_EXPORTER=true
 	run run_otelcol
-	run ! grep -q "otlphttp/external" "$TESTDIR/otelcol-config-export-http.yaml"
+	run ! grep -q "otlp_http/external" "$TESTDIR/otelcol-config-export-http.yaml"
 }
 
 @test "debug only: overlay passed to otelcol" {
@@ -85,9 +85,9 @@ run_otelcol() {
 @test "external only: overlay has external exporters for all signals" {
 	export OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318
 	run run_otelcol
-	grep -q "otlphttp/external-traces" "$TESTDIR/otelcol-config-export-http.yaml"
-	grep -q "otlphttp/external-metrics" "$TESTDIR/otelcol-config-export-http.yaml"
-	grep -q "otlphttp/external-logs" "$TESTDIR/otelcol-config-export-http.yaml"
+	grep -q "otlp_http/external-traces" "$TESTDIR/otelcol-config-export-http.yaml"
+	grep -q "otlp_http/external-metrics" "$TESTDIR/otelcol-config-export-http.yaml"
+	grep -q "otlp_http/external-logs" "$TESTDIR/otelcol-config-export-http.yaml"
 }
 
 @test "external only: overlay has no debug exporters" {
@@ -101,9 +101,9 @@ run_otelcol() {
 @test "per-signal: only configured signals get external exporter" {
 	export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo:4318
 	run run_otelcol
-	grep -q "otlphttp/external-traces" "$TESTDIR/otelcol-config-export-http.yaml"
-	run ! grep -q "otlphttp/external-metrics" "$TESTDIR/otelcol-config-export-http.yaml"
-	run ! grep -q "otlphttp/external-logs" "$TESTDIR/otelcol-config-export-http.yaml"
+	grep -q "otlp_http/external-traces" "$TESTDIR/otelcol-config-export-http.yaml"
+	run ! grep -q "otlp_http/external-metrics" "$TESTDIR/otelcol-config-export-http.yaml"
+	run ! grep -q "otlp_http/external-logs" "$TESTDIR/otelcol-config-export-http.yaml"
 }
 
 # --- both debug and external ---
@@ -115,9 +115,9 @@ run_otelcol() {
 	grep -q "debug/traces" "$TESTDIR/otelcol-config-export-http.yaml"
 	grep -q "debug/metrics" "$TESTDIR/otelcol-config-export-http.yaml"
 	grep -q "debug/logs" "$TESTDIR/otelcol-config-export-http.yaml"
-	grep -q "otlphttp/external-traces" "$TESTDIR/otelcol-config-export-http.yaml"
-	grep -q "otlphttp/external-metrics" "$TESTDIR/otelcol-config-export-http.yaml"
-	grep -q "otlphttp/external-logs" "$TESTDIR/otelcol-config-export-http.yaml"
+	grep -q "otlp_http/external-traces" "$TESTDIR/otelcol-config-export-http.yaml"
+	grep -q "otlp_http/external-metrics" "$TESTDIR/otelcol-config-export-http.yaml"
+	grep -q "otlp_http/external-logs" "$TESTDIR/otelcol-config-export-http.yaml"
 }
 
 @test "both: only one overlay config passed to otelcol" {

--- a/docker/run-otelcol.sh
+++ b/docker/run-otelcol.sh
@@ -11,8 +11,8 @@ render_pipeline_overlay() {
 	for signal in traces metrics logs; do
 		local signal_var="OTEL_EXPORTER_OTLP_${signal^^}_ENDPOINT"
 		if [[ -n ${!signal_var:-} || ${OTEL_COLLECTOR_DEBUG_EXPORTER:-false} == "true" ]]; then
-			local exporters="otlphttp/${signal}"
-			[[ -n ${!signal_var:-} ]] && exporters+=", otlphttp/external-${signal}"
+			local exporters="otlp_http/${signal}"
+			[[ -n ${!signal_var:-} ]] && exporters+=", otlp_http/external-${signal}"
 			[[ ${OTEL_COLLECTOR_DEBUG_EXPORTER:-false} == "true" ]] && exporters+=", debug/${signal}"
 			printf '    %s:\n      exporters: [%s]\n' "${signal}" "${exporters}" >>otelcol-config-export-http.yaml
 		fi
@@ -26,7 +26,7 @@ render_pipeline_overlay() {
 			local signal_var="OTEL_EXPORTER_OTLP_${signal^^}_ENDPOINT"
 			if [[ -n ${!signal_var:-} ]]; then
 				# shellcheck disable=SC2016 # otelcol config template, not bash variables
-				printf '  otlphttp/external-%s:\n    endpoint: ${env:%s}\n' \
+				printf '  otlp_http/external-%s:\n    endpoint: ${env:%s}\n' \
 					"${signal}" "${signal_var}" >>otelcol-config-export-http.yaml
 			fi
 		done

--- a/examples/java/json-logging-ecs/k8s/collector-configmap.yaml
+++ b/examples/java/json-logging-ecs/k8s/collector-configmap.yaml
@@ -135,11 +135,11 @@ data:
         override: false
 
     exporters:
-      otlphttp/metrics:
+      otlp_http/metrics:
         endpoint: http://127.0.0.1:9090/api/v1/otlp
-      otlphttp/traces:
+      otlp_http/traces:
         endpoint: http://127.0.0.1:4418
-      otlphttp/logs:
+      otlp_http/logs:
         endpoint: http://127.0.0.1:3100/otlp
       debug/metrics:
         verbosity: detailed
@@ -154,17 +154,17 @@ data:
         traces:
           receivers: [ otlp ]
           processors: [ batch ]
-          exporters: [ otlphttp/traces ]
+          exporters: [ otlp_http/traces ]
         metrics:
           receivers: [ otlp, prometheus/collector ]
           processors: [ batch ]
-          exporters: [ otlphttp/metrics ]
+          exporters: [ otlp_http/metrics ]
         logs/otlp:
           receivers: [ otlp ]
           processors: [ batch ]
-          exporters: [ otlphttp/logs ]
+          exporters: [ otlp_http/logs ]
         logs/json-ecs:
           receivers: [ filelog/json-ecs ]
           processors: [ batch ]
-          exporters: [ otlphttp/logs ]
-          # exporters: [ otlphttp/logs, debug/logs ]  # Uncomment this line to enable debug logging
+          exporters: [ otlp_http/logs ]
+          # exporters: [ otlp_http/logs, debug/logs ]  # Uncomment this line to enable debug logging

--- a/examples/java/json-logging-logback/k8s/collector-configmap.yaml
+++ b/examples/java/json-logging-logback/k8s/collector-configmap.yaml
@@ -144,11 +144,11 @@ data:
         override: false
 
     exporters:
-      otlphttp/metrics:
+      otlp_http/metrics:
         endpoint: http://127.0.0.1:9090/api/v1/otlp
-      otlphttp/traces:
+      otlp_http/traces:
         endpoint: http://127.0.0.1:4418
-      otlphttp/logs:
+      otlp_http/logs:
         endpoint: http://127.0.0.1:3100/otlp
       debug/metrics:
         verbosity: detailed
@@ -163,17 +163,17 @@ data:
         traces:
           receivers: [ otlp ]
           processors: [ batch ]
-          exporters: [ otlphttp/traces ]
+          exporters: [ otlp_http/traces ]
         metrics:
           receivers: [ otlp, prometheus/collector ]
           processors: [ batch ]
-          exporters: [ otlphttp/metrics ]
+          exporters: [ otlp_http/metrics ]
         logs/otlp:
           receivers: [ otlp ]
           processors: [ batch ]
-          exporters: [ otlphttp/logs ]
+          exporters: [ otlp_http/logs ]
         logs/json-elastic:
           receivers: [ filelog/json-logback ]
           processors: [ batch ]
-          exporters: [ otlphttp/logs ]
-          # exporters: [ otlphttp/logs, debug/logs ]  # Uncomment this line to enable debug logging
+          exporters: [ otlp_http/logs ]
+          # exporters: [ otlp_http/logs, debug/logs ]  # Uncomment this line to enable debug logging

--- a/examples/java/json-logging-otlp/k8s/collector-configmap.yaml
+++ b/examples/java/json-logging-otlp/k8s/collector-configmap.yaml
@@ -36,11 +36,11 @@ data:
       otlpjson:
 
     exporters:
-      otlphttp/metrics:
+      otlp_http/metrics:
         endpoint: http://127.0.0.1:9090/api/v1/otlp
-      otlphttp/traces:
+      otlp_http/traces:
         endpoint: http://127.0.0.1:4418
-      otlphttp/logs:
+      otlp_http/logs:
         endpoint: http://127.0.0.1:3100/otlp
       debug/metrics:
         verbosity: detailed
@@ -55,11 +55,11 @@ data:
         traces:
           receivers: [ otlp ]
           processors: [ batch ]
-          exporters: [ otlphttp/traces ]
+          exporters: [ otlp_http/traces ]
         metrics:
           receivers: [ otlp, prometheus/collector ]
           processors: [ batch ]
-          exporters: [ otlphttp/metrics ]
+          exporters: [ otlp_http/metrics ]
         logs/raw_otlpjson:
           receivers: [ filelog/otlp-json-logs ]
           # No need for processors before the otlpjson connector
@@ -69,5 +69,5 @@ data:
         logs/otlp:
           receivers: [ otlp, otlpjson ]
           processors: [ resourcedetection, batch ]
-          exporters: [ otlphttp/logs ]
-          # exporters: [ otlphttp/logs, debug/logs ]  # Uncomment this line to enable debug logging
+          exporters: [ otlp_http/logs ]
+          # exporters: [ otlp_http/logs, debug/logs ]  # Uncomment this line to enable debug logging


### PR DESCRIPTION
Use the new otel_http instead of the old otelhttp names.

This starts up the collector correctly, but I am not sure if this is enough.

Fixes #1275 