### PR TITLE
Fix warnings during image push

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -31,6 +31,7 @@ jobs:
       cancel-in-progress: false
 
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
       COSIGN_VERSION: v3.0.6
 
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write


### PR DESCRIPTION
Add missing permission to create artifact create storage records.

[Example](https://github.com/grafana/docker-otel-lgtm/actions/runs/24450121462):

```text
Failed to create storage record: Error: Failed to persist storage record: no artifacts found - https://docs.github.com/rest/orgs/artifact-metadata#create-artifact-metadata-storage-record
Please check that the "artifact-metadata:write" permission has been included
```