### PR TITLE
ci: skip PR Docker cache export

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -87,7 +87,7 @@ jobs:
           build-args: |
             LGTM_VERSION=${{ github.ref_name }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
           context: docker/
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
## What changed

Split the container image Buildx step into PR and non-PR variants.

PR builds still use `cache-from: type=gha`, but no longer export `cache-to: type=gha,mode=max`. Push/tag builds keep the existing cache export and image push behavior.

## Why

PR #1315 repeatedly appeared to hang after the image build completed. The logs showed the slow path was GitHub Actions cache export, with minutes spent writing Buildx cache layers before cancellation.

Skipping cache export on PRs keeps the validation build while avoiding long PR cache uploads.

## Validation

- `actionlint .github/workflows/ghcr-image-build-and-publish.yml`
- Attempted `mise run lint:fix`, but full tool installation is blocked in this environment by read-only default home paths for mise/dotnet/rust/node installers.