### PR TITLE
chore: follow up to #1317

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,5 +29,8 @@ jobs:
       - name: CI checks
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: mise run ci


### PR DESCRIPTION
Small follow-up to #1317.

Updates the generated Flint PR workflow env to pass the vars current Rust Flint actually reads for GitHub link remaps:
- `GITHUB_REPOSITORY`
- `GITHUB_BASE_REF`
- `GITHUB_HEAD_REF`
- `PR_HEAD_REPO`

and removes stale `GITHUB_HEAD_SHA`, which Rust Flint no longer uses.