### PR TITLE
chore: upgrade flint to v0.22.2

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,2 +1,0 @@
-[codespell]
-ignore-words-list = atMost,equest

--- a/.github/config/_typos.toml
+++ b/.github/config/_typos.toml
@@ -1,0 +1,8 @@
+[default]
+extend-ignore-re = [
+  '\*\.\[Pp\]ublish\.xml',
+  '# RED Metrics: \(r\)equest rate, \(e\)rror rate, \(d\)uration',
+  '\.atMost\(',
+  '# Paket dependency manager',
+  '# Tye',
+]

--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -1,310 +1,342 @@
 {
-  ".github/renovate.json5": {
-    "renovate-config-presets": [
-      "grafana/flint"
-    ]
+  "meta": {
+    "grafana": {
+      "packageName": "grafana/grafana",
+      "datasource": "github-releases"
+    },
+    "loki": {
+      "packageName": "grafana/loki",
+      "datasource": "github-releases"
+    },
+    "obi": {
+      "packageName": "open-telemetry/opentelemetry-ebpf-instrumentation",
+      "datasource": "github-releases"
+    },
+    "opentelemetry-collector": {
+      "packageName": "open-telemetry/opentelemetry-collector-releases",
+      "datasource": "github-releases"
+    },
+    "prometheus": {
+      "packageName": "prometheus/prometheus",
+      "datasource": "github-releases"
+    },
+    "pyroscope": {
+      "packageName": "grafana/pyroscope",
+      "datasource": "github-releases"
+    },
+    "tempo": {
+      "packageName": "grafana/tempo",
+      "datasource": "github-releases"
+    }
   },
-  ".github/workflows/acceptance-tests.yml": {
-    "regex": [
-      "mise"
-    ]
-  },
-  ".github/workflows/ghcr-image-build-and-publish.yml": {
-    "regex": [
-      "cosign"
-    ]
-  },
-  ".github/workflows/lint.yml": {
-    "regex": [
-      "mise"
-    ]
-  },
-  ".github/workflows/release.yml": {
-    "regex": [
-      "cosign"
-    ]
-  },
-  "docker/Dockerfile": {
-    "dockerfile": [
-      "docker.io/otel/ebpf-instrument",
-      "docker.io/redhat/ubi9",
-      "docker.io/redhat/ubi9-micro"
-    ],
-    "regex": [
-      "cosign",
-      "grafana",
-      "loki",
-      "obi",
-      "opentelemetry-collector",
-      "prometheus",
-      "pyroscope",
-      "tempo"
-    ]
-  },
-  "examples/dotnet/Dockerfile": {
-    "dockerfile": [
-      "mcr.microsoft.com/dotnet/aspnet",
-      "mcr.microsoft.com/dotnet/sdk"
-    ]
-  },
-  "examples/dotnet/docker-compose.yml": {
-    "docker-compose": [
-      "grafana/otel-lgtm"
-    ]
-  },
-  "examples/dotnet/rolldice.csproj": {
-    "nuget": [
-      "OpenTelemetry.Exporter.Console",
-      "OpenTelemetry.Exporter.OpenTelemetryProtocol",
-      "OpenTelemetry.Extensions.Hosting",
-      "OpenTelemetry.Instrumentation.AspNetCore",
-      "OpenTelemetry.Instrumentation.Http"
-    ]
-  },
-  "examples/ebpf-profiler/Dockerfile": {
-    "dockerfile": [
-      "otel/opentelemetry-ebpf-profiler-dev",
-      "ubuntu"
-    ],
-    "regex": [
-      "opentelemetry-ebpf-profiler"
-    ]
-  },
-  "examples/ebpf-profiler/docker-compose.yml": {
-    "docker-compose": [
-      "grafana/otel-lgtm"
-    ]
-  },
-  "examples/ebpf-profiler/generate-traffic.Dockerfile": {
-    "dockerfile": [
-      "ubuntu"
-    ]
-  },
-  "examples/go/Dockerfile": {
-    "dockerfile": [
-      "golang"
-    ]
-  },
-  "examples/go/go.mod": {
-    "gomod": [
-      "github.com/cenkalti/backoff/v5",
-      "github.com/cespare/xxhash/v2",
-      "github.com/felixge/httpsnoop",
-      "github.com/go-logr/logr",
-      "github.com/go-logr/stdr",
-      "github.com/google/uuid",
-      "github.com/grpc-ecosystem/grpc-gateway/v2",
-      "go",
-      "go.opentelemetry.io/auto/sdk",
-      "go.opentelemetry.io/contrib/bridges/otelslog",
-      "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
-      "go.opentelemetry.io/contrib/instrumentation/runtime",
-      "go.opentelemetry.io/otel",
-      "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp",
-      "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp",
-      "go.opentelemetry.io/otel/exporters/otlp/otlptrace",
-      "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp",
-      "go.opentelemetry.io/otel/log",
-      "go.opentelemetry.io/otel/metric",
-      "go.opentelemetry.io/otel/sdk",
-      "go.opentelemetry.io/otel/sdk/log",
-      "go.opentelemetry.io/otel/sdk/metric",
-      "go.opentelemetry.io/otel/trace",
-      "go.opentelemetry.io/proto/otlp",
-      "golang.org/x/net",
-      "golang.org/x/sys",
-      "golang.org/x/text",
-      "google.golang.org/genproto/googleapis/api",
-      "google.golang.org/genproto/googleapis/rpc",
-      "google.golang.org/grpc",
-      "google.golang.org/protobuf"
-    ]
-  },
-  "examples/java/.mvn/wrapper/maven-wrapper.properties": {
-    "maven-wrapper": [
-      "maven"
-    ]
-  },
-  "examples/java/Dockerfile": {
-    "dockerfile": [
-      "eclipse-temurin",
-      "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java"
-    ]
-  },
-  "examples/java/docker-compose.yml": {
-    "docker-compose": [
-      "grafana/otel-lgtm"
-    ]
-  },
-  "examples/java/json-logging-ecs/Dockerfile": {
-    "dockerfile": [
-      "eclipse-temurin"
-    ]
-  },
-  "examples/java/json-logging-logback/Dockerfile": {
-    "dockerfile": [
-      "eclipse-temurin"
-    ]
-  },
-  "examples/java/json-logging-otlp/Dockerfile": {
-    "dockerfile": [
-      "eclipse-temurin",
-      "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java"
-    ]
-  },
-  "examples/java/mvnw": {
-    "maven-wrapper": [
-      "maven-wrapper"
-    ]
-  },
-  "examples/java/mvnw.cmd": {
-    "maven-wrapper": [
-      "maven-wrapper"
-    ]
-  },
-  "examples/java/pom.xml": {
-    "maven": [
-      "org.springframework.boot:spring-boot-dependencies"
-    ]
-  },
-  "examples/java/run.sh": {
-    "regex": [
-      "opentelemetry-java-instrumentation"
-    ]
-  },
-  "examples/java/testcontainer/pom.xml": {
-    "maven": [
-      "io.opentelemetry:opentelemetry-bom-alpha",
-      "org.assertj:assertj-core",
-      "org.awaitility:awaitility",
-      "org.junit.jupiter:junit-jupiter",
-      "org.testcontainers:testcontainers-bom"
-    ]
-  },
-  "examples/nodejs/Dockerfile": {
-    "dockerfile": [
-      "docker/dockerfile",
-      "node"
-    ]
-  },
-  "examples/nodejs/package.json": {
-    "npm": [
-      "@opentelemetry/api",
-      "@opentelemetry/api-logs",
-      "@opentelemetry/auto-instrumentations-node",
-      "@opentelemetry/exporter-logs-otlp-proto",
-      "@opentelemetry/exporter-metrics-otlp-proto",
-      "@opentelemetry/exporter-trace-otlp-proto",
-      "@opentelemetry/resources",
-      "@opentelemetry/sdk-logs",
-      "@opentelemetry/sdk-metrics",
-      "@opentelemetry/sdk-node",
-      "@opentelemetry/sdk-trace-node",
-      "@opentelemetry/semantic-conventions",
-      "express"
-    ]
-  },
-  "examples/obi/docker-compose.yaml": {
-    "docker-compose": [
-      "grafana/otel-lgtm"
-    ]
-  },
-  "examples/obi/dotnet/Dockerfile": {
-    "dockerfile": [
-      "mcr.microsoft.com/dotnet/aspnet",
-      "mcr.microsoft.com/dotnet/sdk"
-    ]
-  },
-  "examples/obi/generate-traffic.Dockerfile": {
-    "dockerfile": [
-      "ubuntu"
-    ]
-  },
-  "examples/obi/go/Dockerfile": {
-    "dockerfile": [
-      "golang"
-    ]
-  },
-  "examples/obi/go/go.mod": {
-    "gomod": [
-      "go"
-    ]
-  },
-  "examples/obi/java.Dockerfile": {
-    "dockerfile": [
-      "eclipse-temurin"
-    ]
-  },
-  "examples/obi/nodejs/Dockerfile": {
-    "dockerfile": [
-      "node"
-    ]
-  },
-  "examples/obi/nodejs/package.json": {
-    "npm": [
-      "express"
-    ]
-  },
-  "examples/obi/python.Dockerfile": {
-    "dockerfile": [
-      "python"
-    ]
-  },
-  "examples/python/Dockerfile": {
-    "dockerfile": [
-      "python"
-    ],
-    "regex": [
-      "opentelemetry-distro"
-    ]
-  },
-  "examples/python/requirements.txt": {
-    "pip_requirements": [
-      "Flask",
-      "Jinja2",
-      "MarkupSafe",
-      "Werkzeug",
-      "blinker",
-      "click",
-      "itsdangerous"
-    ]
-  },
-  "examples/python/run.sh": {
-    "regex": [
-      "opentelemetry-distro"
-    ]
-  },
-  "go.mod": {
-    "gomod": [
-      "go"
-    ]
-  },
-  "mise.toml": {
-    "mise": [
-      "actionlint",
-      "aqua:owenlamont/ryl",
-      "bats",
-      "biome",
-      "dotnet",
-      "editorconfig-checker",
-      "github:google/google-java-format",
-      "github:grafana/flint",
-      "github:jonwiggins/xmloxide",
-      "github:koalaman/shellcheck",
-      "go",
-      "go:github.com/grafana/oats",
-      "golangci-lint",
-      "hadolint",
-      "java",
-      "lychee",
-      "node",
-      "npm:renovate",
-      "pipx:codespell",
-      "ruff",
-      "rumdl",
-      "rust",
-      "shfmt",
-      "taplo"
-    ]
+  "files": {
+    ".github/renovate.json5": {
+      "renovate-config-presets": [
+        "grafana/flint"
+      ]
+    },
+    ".github/workflows/acceptance-tests.yml": {
+      "regex": [
+        "mise"
+      ]
+    },
+    ".github/workflows/ghcr-image-build-and-publish.yml": {
+      "regex": [
+        "cosign"
+      ]
+    },
+    ".github/workflows/lint.yml": {
+      "regex": [
+        "mise"
+      ]
+    },
+    ".github/workflows/release.yml": {
+      "regex": [
+        "cosign"
+      ]
+    },
+    "docker/Dockerfile": {
+      "dockerfile": [
+        "docker.io/otel/ebpf-instrument",
+        "docker.io/redhat/ubi9",
+        "docker.io/redhat/ubi9-micro"
+      ],
+      "regex": [
+        "cosign",
+        "grafana",
+        "loki",
+        "obi",
+        "opentelemetry-collector",
+        "prometheus",
+        "pyroscope",
+        "tempo"
+      ]
+    },
+    "examples/dotnet/Dockerfile": {
+      "dockerfile": [
+        "mcr.microsoft.com/dotnet/aspnet",
+        "mcr.microsoft.com/dotnet/sdk"
+      ]
+    },
+    "examples/dotnet/docker-compose.yml": {
+      "docker-compose": [
+        "grafana/otel-lgtm"
+      ]
+    },
+    "examples/dotnet/rolldice.csproj": {
+      "nuget": [
+        "OpenTelemetry.Exporter.Console",
+        "OpenTelemetry.Exporter.OpenTelemetryProtocol",
+        "OpenTelemetry.Extensions.Hosting",
+        "OpenTelemetry.Instrumentation.AspNetCore",
+        "OpenTelemetry.Instrumentation.Http"
+      ]
+    },
+    "examples/ebpf-profiler/Dockerfile": {
+      "dockerfile": [
+        "otel/opentelemetry-ebpf-profiler-dev",
+        "ubuntu"
+      ],
+      "regex": [
+        "opentelemetry-ebpf-profiler"
+      ]
+    },
+    "examples/ebpf-profiler/docker-compose.yml": {
+      "docker-compose": [
+        "grafana/otel-lgtm"
+      ]
+    },
+    "examples/ebpf-profiler/generate-traffic.Dockerfile": {
+      "dockerfile": [
+        "ubuntu"
+      ]
+    },
+    "examples/go/Dockerfile": {
+      "dockerfile": [
+        "golang"
+      ]
+    },
+    "examples/go/go.mod": {
+      "gomod": [
+        "github.com/cenkalti/backoff/v5",
+        "github.com/cespare/xxhash/v2",
+        "github.com/felixge/httpsnoop",
+        "github.com/go-logr/logr",
+        "github.com/go-logr/stdr",
+        "github.com/google/uuid",
+        "github.com/grpc-ecosystem/grpc-gateway/v2",
+        "go",
+        "go.opentelemetry.io/auto/sdk",
+        "go.opentelemetry.io/contrib/bridges/otelslog",
+        "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+        "go.opentelemetry.io/contrib/instrumentation/runtime",
+        "go.opentelemetry.io/otel",
+        "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp",
+        "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp",
+        "go.opentelemetry.io/otel/exporters/otlp/otlptrace",
+        "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp",
+        "go.opentelemetry.io/otel/log",
+        "go.opentelemetry.io/otel/metric",
+        "go.opentelemetry.io/otel/sdk",
+        "go.opentelemetry.io/otel/sdk/log",
+        "go.opentelemetry.io/otel/sdk/metric",
+        "go.opentelemetry.io/otel/trace",
+        "go.opentelemetry.io/proto/otlp",
+        "golang.org/x/net",
+        "golang.org/x/sys",
+        "golang.org/x/text",
+        "google.golang.org/genproto/googleapis/api",
+        "google.golang.org/genproto/googleapis/rpc",
+        "google.golang.org/grpc",
+        "google.golang.org/protobuf"
+      ]
+    },
+    "examples/java/.mvn/wrapper/maven-wrapper.properties": {
+      "maven-wrapper": [
+        "maven"
+      ]
+    },
+    "examples/java/Dockerfile": {
+      "dockerfile": [
+        "eclipse-temurin",
+        "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java"
+      ]
+    },
+    "examples/java/docker-compose.yml": {
+      "docker-compose": [
+        "grafana/otel-lgtm"
+      ]
+    },
+    "examples/java/json-logging-ecs/Dockerfile": {
+      "dockerfile": [
+        "eclipse-temurin"
+      ]
+    },
+    "examples/java/json-logging-logback/Dockerfile": {
+      "dockerfile": [
+        "eclipse-temurin"
+      ]
+    },
+    "examples/java/json-logging-otlp/Dockerfile": {
+      "dockerfile": [
+        "eclipse-temurin",
+        "ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java"
+      ]
+    },
+    "examples/java/mvnw": {
+      "maven-wrapper": [
+        "maven-wrapper"
+      ]
+    },
+    "examples/java/mvnw.cmd": {
+      "maven-wrapper": [
+        "maven-wrapper"
+      ]
+    },
+    "examples/java/pom.xml": {
+      "maven": [
+        "org.springframework.boot:spring-boot-dependencies"
+      ]
+    },
+    "examples/java/run.sh": {
+      "regex": [
+        "opentelemetry-java-instrumentation"
+      ]
+    },
+    "examples/java/testcontainer/pom.xml": {
+      "maven": [
+        "io.opentelemetry:opentelemetry-bom-alpha",
+        "org.assertj:assertj-core",
+        "org.awaitility:awaitility",
+        "org.junit.jupiter:junit-jupiter",
+        "org.testcontainers:testcontainers-bom"
+      ]
+    },
+    "examples/nodejs/Dockerfile": {
+      "dockerfile": [
+        "docker/dockerfile",
+        "node"
+      ]
+    },
+    "examples/nodejs/package.json": {
+      "npm": [
+        "@opentelemetry/api",
+        "@opentelemetry/api-logs",
+        "@opentelemetry/auto-instrumentations-node",
+        "@opentelemetry/exporter-logs-otlp-proto",
+        "@opentelemetry/exporter-metrics-otlp-proto",
+        "@opentelemetry/exporter-trace-otlp-proto",
+        "@opentelemetry/resources",
+        "@opentelemetry/sdk-logs",
+        "@opentelemetry/sdk-metrics",
+        "@opentelemetry/sdk-node",
+        "@opentelemetry/sdk-trace-node",
+        "@opentelemetry/semantic-conventions",
+        "express"
+      ]
+    },
+    "examples/obi/docker-compose.yaml": {
+      "docker-compose": [
+        "grafana/otel-lgtm"
+      ]
+    },
+    "examples/obi/dotnet/Dockerfile": {
+      "dockerfile": [
+        "mcr.microsoft.com/dotnet/aspnet",
+        "mcr.microsoft.com/dotnet/sdk"
+      ]
+    },
+    "examples/obi/generate-traffic.Dockerfile": {
+      "dockerfile": [
+        "ubuntu"
+      ]
+    },
+    "examples/obi/go/Dockerfile": {
+      "dockerfile": [
+        "golang"
+      ]
+    },
+    "examples/obi/go/go.mod": {
+      "gomod": [
+        "go"
+      ]
+    },
+    "examples/obi/java.Dockerfile": {
+      "dockerfile": [
+        "eclipse-temurin"
+      ]
+    },
+    "examples/obi/nodejs/Dockerfile": {
+      "dockerfile": [
+        "node"
+      ]
+    },
+    "examples/obi/nodejs/package.json": {
+      "npm": [
+        "express"
+      ]
+    },
+    "examples/obi/python.Dockerfile": {
+      "dockerfile": [
+        "python"
+      ]
+    },
+    "examples/python/Dockerfile": {
+      "dockerfile": [
+        "python"
+      ],
+      "regex": [
+        "opentelemetry-distro"
+      ]
+    },
+    "examples/python/requirements.txt": {
+      "pip_requirements": [
+        "Flask",
+        "Jinja2",
+        "MarkupSafe",
+        "Werkzeug",
+        "blinker",
+        "click",
+        "itsdangerous"
+      ]
+    },
+    "examples/python/run.sh": {
+      "regex": [
+        "opentelemetry-distro"
+      ]
+    },
+    "go.mod": {
+      "gomod": [
+        "go"
+      ]
+    },
+    "mise.toml": {
+      "mise": [
+        "actionlint",
+        "aqua:grafana/flint",
+        "aqua:jonwiggins/xmloxide",
+        "aqua:owenlamont/ryl",
+        "bats",
+        "biome",
+        "dotnet",
+        "editorconfig-checker",
+        "go",
+        "go:github.com/grafana/oats",
+        "golangci-lint",
+        "google-java-format",
+        "hadolint",
+        "java",
+        "lychee",
+        "node",
+        "npm:renovate",
+        "ruff",
+        "rumdl",
+        "rust",
+        "shellcheck",
+        "shfmt",
+        "taplo",
+        "typos"
+      ]
+    }
   }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -10,22 +10,22 @@ rust = { version = "1.95.0", components = "clippy,rustfmt" }
 
 # Linters
 actionlint = "1.7.12"
+"aqua:grafana/flint" = "0.22.2"
+"aqua:jonwiggins/xmloxide" = "0.4.2"
 "aqua:owenlamont/ryl" = "0.9.1"
 biome = "2.4.13"
 editorconfig-checker = "3.6.1"
-"github:google/google-java-format" = "1.35.0"
-"github:grafana/flint" = "0.21.0"
-"github:jonwiggins/xmloxide" = "0.4.2"
-"github:koalaman/shellcheck" = "0.11.0"
 golangci-lint = "2.12.2"
+google-java-format = "1.35.0"
 hadolint = "2.14.0"
 lychee = "0.24.2"
 "npm:renovate" = "43.150.0"
-"pipx:codespell" = "2.4.2"
 ruff = "0.15.12"
 rumdl = "0.1.80"
+shellcheck = "0.11.0"
 shfmt = "3.13.1"
 taplo = "0.10.0"
+typos = "1.46.0"
 
 [env]
 FLINT_CONFIG_DIR = ".github/config"


### PR DESCRIPTION
## Summary
- upgrade the Flint pin to `v0.22.2`
- migrate from `codespell` to `typos`
- add Flint-managed `_typos.toml` and remove legacy `.codespellrc`
- refresh the Renovate tracked-deps snapshot
- fix newly surfaced typos found during the rollout

## Why
`grafana/flint` `v0.22.2` includes the upstream fixes needed for consumer rollout:
- aqua attestation/install path fixed
- `renovate-deps` no longer fails on mixed-manager `go` metadata
- `codespell` to `typos` migration no longer carries an invalid version

## Validation
- `mise run lint`
- `mise run test:unit`
- confirmed `mise` installs `aqua:grafana/flint@0.22.2` with attestation verification enabled