### PR TITLE
Fix: MCP docs link version handling

### DIFF
--- a/docker/run-all.bats
+++ b/docker/run-all.bats
@@ -83,6 +83,23 @@ run_run_all() {
 	[[ "$output" == *"$expected_line"* ]]
 }
 
+
+@test "docs URL uses main for main tag" {
+	local expected="https://github.com/grafana/docker-otel-lgtm/blob/main/docs/mcp-integration.md"
+	local expected_line="  Docs:         $expected"
+	run run_run_all "main"
+	[[ "$output" == *"$expected_line"* ]]
+	[[ "$output" != *"/blob/vmain/"* ]]
+}
+
+@test "printed MCP commands escape configurable paths" {
+	local configdir="$TESTDIR/etc/lgtm with spaces"
+	local escaped_configdir=${configdir// /\\ }
+	CONFIGDIR="$configdir" run run_run_all "latest"
+	[[ "$output" == *"bash <(docker exec lgtm cat ${escaped_configdir}/claude-mcp-setup.sh)"* ]]
+	[[ "$output" == *"docker exec lgtm cat ${escaped_configdir}/mcp.json"* ]]
+}
+
 @test "docs URL prefixes bare release version with v" {
 	local expected
 	expected="https://github.com/grafana/docker-otel-lgtm/blob/v1.2.3-test/docs/mcp-integration.md"

--- a/docker/run-all.bats
+++ b/docker/run-all.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+setup() {
+	TESTDIR=$(mktemp -d)
+	CONFIGDIR="$TESTDIR/etc/lgtm"
+	TOKENFILE="$TESTDIR/tmp/grafana-sa-token"
+	mkdir -p "$(dirname "$TOKENFILE")"
+	cp "$BATS_TEST_DIRNAME/run-all.sh" "$TESTDIR/"
+
+	for script in \
+		run-grafana.sh \
+		run-loki.sh \
+		run-otelcol.sh \
+		run-prometheus.sh \
+		run-tempo.sh \
+		run-pyroscope.sh; do
+		cat >"$TESTDIR/$script" <<'EOF'
+#!/usr/bin/env bash
+sleep 60
+EOF
+		chmod +x "$TESTDIR/$script"
+	done
+
+	cat >"$TESTDIR/curl" <<'EOF'
+#!/usr/bin/env bash
+args="$*"
+
+if [[ "$args" == *"/ready"* ||
+	"$args" == *"/api/health"* ||
+	"$args" == *"/api/v1/status/runtimeinfo"* ]]; then
+	printf '200'
+	exit 0
+fi
+
+if [[ "$args" == *"/api/serviceaccounts/1/tokens"* && "$args" == *"-d"* ]]; then
+	printf '{"key":"token123"}'
+	exit 0
+fi
+
+if [[ "$args" == *"/api/serviceaccounts/1/tokens"* ]]; then
+	printf '[]'
+	exit 0
+fi
+
+if [[ "$args" == *"/api/serviceaccounts"* && "$args" == *"-d"* ]]; then
+	printf '{"id":1}'
+	exit 0
+fi
+
+printf '{}'
+EOF
+	chmod +x "$TESTDIR/curl"
+}
+
+teardown() {
+	rm -rf "$TESTDIR"
+}
+
+run_run_all() {
+	local version=$1
+	cd "$TESTDIR" || return 1
+	PATH="$TESTDIR:$PATH" \
+		LGTM_CONFIG_DIR="$CONFIGDIR" \
+		GRAFANA_SA_TOKEN_FILE="$TOKENFILE" \
+		LGTM_VERSION="$version" \
+		CONTAINER_RUNTIME=docker \
+			timeout 3s bash ./run-all.sh
+}
+
+@test "docs URL uses main for latest" {
+	local expected="https://github.com/grafana/docker-otel-lgtm/blob/main/docs/mcp-integration.md"
+	local expected_line="  Docs:         $expected"
+	run run_run_all "latest"
+	[[ "$output" == *"$expected_line"* ]]
+	[[ "$output" != *"/blob/vlatest/"* ]]
+}
+
+@test "docs URL uses main when version is empty" {
+	local expected="https://github.com/grafana/docker-otel-lgtm/blob/main/docs/mcp-integration.md"
+	local expected_line="  Docs:         $expected"
+	run run_run_all ""
+	[[ "$output" == *"$expected_line"* ]]
+}
+
+@test "docs URL prefixes bare release version with v" {
+	local expected
+	expected="https://github.com/grafana/docker-otel-lgtm/blob/v1.2.3-test/docs/mcp-integration.md"
+	local expected_line="  Docs:         $expected"
+	run run_run_all "1.2.3-test"
+	[[ "$output" == *"$expected_line"* ]]
+}
+
+@test "docs URL does not double-prefix version that already starts with v" {
+	local expected
+	expected="https://github.com/grafana/docker-otel-lgtm/blob/v1.2.3-test/docs/mcp-integration.md"
+	local expected_line="  Docs:         $expected"
+	run run_run_all "v1.2.3-test"
+	[[ "$output" == *"$expected_line"* ]]
+	[[ "$output" != *"/blob/vv1.2.3-test/"* ]]
+}
+
+@test "MCP bootstrap writes helper artifacts with expected contents" {
+	run run_run_all "latest"
+	[ -f "$CONFIGDIR/mcp.json" ]
+	[ -f "$CONFIGDIR/claude-mcp-setup.sh" ]
+	[ -f "$TOKENFILE" ]
+
+	grep -Fq \
+		'"GRAFANA_URL": "http://localhost:3000"' \
+		"$CONFIGDIR/mcp.json"
+	grep -Fq \
+		'"GRAFANA_SERVICE_ACCOUNT_TOKEN": "token123"' \
+		"$CONFIGDIR/mcp.json"
+	grep -Fq '"url": "http://localhost:3200/api/mcp"' "$CONFIGDIR/mcp.json"
+
+	grep -Fq \
+		'claude mcp add grafana -e "GRAFANA_URL=http://localhost:3000"' \
+		"$CONFIGDIR/claude-mcp-setup.sh"
+	grep -Fq \
+		'GRAFANA_SERVICE_ACCOUNT_TOKEN=token123' \
+		"$CONFIGDIR/claude-mcp-setup.sh"
+	grep -Fq \
+		'claude mcp add --transport http tempo "http://localhost:3200/api/mcp"' \
+		"$CONFIGDIR/claude-mcp-setup.sh"
+
+	grep -Fqx 'token123' "$TOKENFILE"
+}

--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -208,10 +208,10 @@ if [ -n "$SA_ID" ]; then
 		)
 		echo ""
 		echo "AI Tool Integration (MCP):"
-		echo "  Claude Code:  bash <($EXEC cat ${LGTM_CONFIG_DIR}/claude-mcp-setup.sh)"
-		echo "  Other tools:  $EXEC cat ${LGTM_CONFIG_DIR}/mcp.json"
+		printf '  Claude Code:  bash <(%s cat %q)\n' "$EXEC" "${LGTM_CONFIG_DIR}/claude-mcp-setup.sh"
+		printf '  Other tools:  %s cat %q\n' "$EXEC" "${LGTM_CONFIG_DIR}/mcp.json"
 		docs_ref="main"
-		if [[ -n "${LGTM_VERSION}" && "${LGTM_VERSION}" != "latest" ]]; then
+		if [[ -n "${LGTM_VERSION}" && "${LGTM_VERSION}" != "latest" && "${LGTM_VERSION}" != "main" ]]; then
 			docs_ref="${LGTM_VERSION}"
 			[[ "${docs_ref}" != v* ]] && docs_ref="v${docs_ref}"
 		fi

--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -147,6 +147,8 @@ GRAFANA_CREDS="${GF_SECURITY_ADMIN_USER:-admin}:${GF_SECURITY_ADMIN_PASSWORD:-ad
 GRAFANA_URL="${GRAFANA_URL:-http://127.0.0.1:3000}"
 GRAFANA_PUBLIC_URL="${GRAFANA_PUBLIC_URL:-http://localhost:3000}"
 TEMPO_URL="${TEMPO_URL:-http://localhost:3200}"
+LGTM_CONFIG_DIR="${LGTM_CONFIG_DIR:-/etc/lgtm}"
+GRAFANA_SA_TOKEN_FILE="${GRAFANA_SA_TOKEN_FILE:-/tmp/grafana-sa-token}"
 SA_NAME="ai-tools"
 SA_TOKEN_NAME="ai-tools-token"
 GRAFANA_SA_URL="${GRAFANA_URL}/api/serviceaccounts"
@@ -178,9 +180,9 @@ if [ -n "$SA_ID" ]; then
 		EXEC="${CONTAINER_RUNTIME:-docker} exec lgtm"
 		(
 			umask 077
-			mkdir -p /etc/lgtm
-			echo "${SA_TOKEN}" >/tmp/grafana-sa-token
-			cat >/etc/lgtm/mcp.json <<-MCPEOF
+			mkdir -p "${LGTM_CONFIG_DIR}"
+			echo "${SA_TOKEN}" >"${GRAFANA_SA_TOKEN_FILE}"
+			cat >"${LGTM_CONFIG_DIR}/mcp.json" <<-MCPEOF
 				{
 				  "mcpServers": {
 				    "grafana": {
@@ -197,7 +199,7 @@ if [ -n "$SA_ID" ]; then
 				  }
 				}
 			MCPEOF
-			cat >/etc/lgtm/claude-mcp-setup.sh <<-SETUPEOF
+			cat >"${LGTM_CONFIG_DIR}/claude-mcp-setup.sh" <<-SETUPEOF
 				#!/usr/bin/env bash
 				# Connect Claude Code to the LGTM stack
 				claude mcp add grafana -e "GRAFANA_URL=${GRAFANA_PUBLIC_URL}" -e "GRAFANA_SERVICE_ACCOUNT_TOKEN=${SA_TOKEN}" -- uvx mcp-grafana
@@ -206,10 +208,13 @@ if [ -n "$SA_ID" ]; then
 		)
 		echo ""
 		echo "AI Tool Integration (MCP):"
-		echo "  Claude Code:  bash <($EXEC cat /etc/lgtm/claude-mcp-setup.sh)"
-		echo "  Other tools:  $EXEC cat /etc/lgtm/mcp.json"
+		echo "  Claude Code:  bash <($EXEC cat ${LGTM_CONFIG_DIR}/claude-mcp-setup.sh)"
+		echo "  Other tools:  $EXEC cat ${LGTM_CONFIG_DIR}/mcp.json"
 		docs_ref="main"
-		[[ -n "${LGTM_VERSION}" ]] && docs_ref="v${LGTM_VERSION}"
+		if [[ -n "${LGTM_VERSION}" && "${LGTM_VERSION}" != "latest" ]]; then
+			docs_ref="${LGTM_VERSION}"
+			[[ "${docs_ref}" != v* ]] && docs_ref="v${docs_ref}"
+		fi
 		echo "  Docs:         https://github.com/grafana/docker-otel-lgtm/blob/${docs_ref}/docs/mcp-integration.md"
 	fi
 fi

--- a/mise.toml
+++ b/mise.toml
@@ -32,7 +32,7 @@ FLINT_CONFIG_DIR = ".github/config"
 
 [tasks."test:unit"]
 description = "Run unit tests"
-run = "bats docker/run-otelcol.bats"
+run = "bats docker/run-otelcol.bats docker/run-all.bats"
 
 [tasks."ci"]
 description = "Run all checks (lint + unit tests)"


### PR DESCRIPTION
## What changed
- fix the MCP docs link printed at startup so `latest` points to `main`
- avoid double-prefixing versions that already start with `v`
- add unit tests covering docs link generation and MCP bootstrap artifact output
- include the new `run-all.bats` test in `mise run test:unit`
- make the MCP config and token output paths overridable for testability while keeping the existing runtime defaults

## Why it changed
The startup message could print invalid GitHub links such as `vlatest` or `vv0.27.1`, which sends users to 404 pages.

## User impact
Users running the container now get a valid `docs/mcp-integration.md` link for both `latest` and versioned images.

## Root cause
The script always prefixed non-empty `LGTM_VERSION` values with `v`, without treating `latest` specially or checking whether the version already included the `v` prefix.

## Validation
- `mise run lint`
- `mise run test:unit`