### PR TITLE
ci: set default workflow token permissions

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -14,6 +14,8 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions: {}
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary

Adds a top-level `permissions: {}` default to the container image workflow while keeping the existing job-level permissions for publishing.

This is a canary remediation for the `github-actions.missing-permissions` finding from the draft security-hardening skill.

## Validation

- `security_hardening.py detect --repo . --repo-name grafana/docker-otel-lgtm --modules github-actions --jsonl /tmp/docker-actions.jsonl`