### PR TITLE
chore: use shared workflow for image build

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -40,11 +40,6 @@
         "mise"
       ]
     },
-    ".github/workflows/ghcr-image-build-and-publish.yml": {
-      "regex": [
-        "cosign"
-      ]
-    },
     ".github/workflows/lint.yml": {
       "regex": [
         "mise"

--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -40,6 +40,11 @@
         "mise"
       ]
     },
+    ".github/workflows/ghcr-image-build-and-publish.yml": {
+      "regex": [
+        "cosign"
+      ]
+    },
     ".github/workflows/lint.yml": {
       "regex": [
         "mise"

--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -1,25 +1,16 @@
 ---
 name: Container Image Build
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   push:
     branches: ["main"]
-    # Publish semver tags as releases.
     tags: ["v*.*.*"]
   pull_request:
     branches: ["main"]
 
 env:
-  # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
-  # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
-  # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
   COSIGN_VERSION: v3.0.6
 
 jobs:
@@ -47,52 +38,29 @@ jobs:
         shell: bash
         run: echo "GIT_COMMIT_EPOCH=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+      - id: push
+        uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          SOURCE_DATE_EPOCH: ${{ env.GIT_COMMIT_EPOCH }}
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          context: docker
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          registries: ghcr
+          image-name: ${{ env.IMAGE_NAME }}
+          build-args: |
+            LGTM_VERSION=${{ github.ref_name }}
+          tags: |-
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
           labels: |-
             org.opencontainers.image.ref.name=${{ github.ref_name }}
             org.opencontainers.image.revision=${{ github.sha }}
             vcs-ref=${{ github.sha }}
             version=${{ github.ref_name }}
-
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        env:
-          SOURCE_DATE_EPOCH: ${{ env.GIT_COMMIT_EPOCH }}
-        with:
-          annotations: ${{ steps.meta.outputs.annotations }}
-          build-args: |
-            LGTM_VERSION=${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
-          context: docker/
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
@@ -112,5 +80,5 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
-          TAGS: ${{ steps.meta.outputs.tags }}
+          TAGS: ${{ steps.push.outputs.tags }}
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes "{}@${DIGEST}"

--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -11,6 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
   COSIGN_VERSION: v3.0.6
 
 jobs:

--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -39,7 +39,8 @@ jobs:
         shell: bash
         run: echo "GIT_COMMIT_EPOCH=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
 
-      - id: push
+      - name: Build and push Docker image
+        id: push
         uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
@@ -55,6 +56,7 @@ jobs:
           tags: |-
             type=ref,event=branch
             type=ref,event=pr
+            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
           labels: |-

--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
         run: echo "GIT_COMMIT_EPOCH=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
 
-      - name: Build and push Docker image
+      - name: Build and push GHCR image
         id: push
         uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
         env:


### PR DESCRIPTION
## What changed
- replaced the direct `docker/build-push-action` based GHCR image build workflow with `grafana/shared-workflows/actions/docker-build-push-image`
- pinned the shared action to immutable release `docker-build-push-image/v0.3.3`
- kept attestation and cosign signing steps in place
- included the repo-local Renovate tracking file update produced by the repo's lint/fix hook

## Why
This is the Docker-path canary for the `security-hardening` shared-workflows replacement catalog.
The same repository already has a migrated example in `release.yml`, so this is the lowest-risk repo to validate the broader shared workflow adoption path.

## Impact
- reduces custom workflow glue in this workflow
- moves the image build/push step to a Grafana-maintained shared action
- gives the scanner a concrete shared-workflows migration PR to reference

## Validation
- compared the target workflow with this repo's existing `release.yml`
- verified the target shared action release exists in `grafana/shared-workflows`
- allowed the repo-local `mise`/`flint` fixer to update tracked dependency metadata
- no repo-specific runtime checks were run; this is a focused workflow-reference canary
