### PR TITLE
otel-config.yaml rename `otlp` to `otlp_grpc` according naming convention

### DIFF
--- a/docker/otelcol-config.yaml
+++ b/docker/otelcol-config.yaml
@@ -37,7 +37,7 @@ exporters:
     endpoint: http://127.0.0.1:3100/otlp
     tls:
       insecure: true
-  otlp/profiles:
+  otlp_grpc/profiles:
     endpoint: http://127.0.0.1:4040
     tls:
       insecure: true
@@ -68,4 +68,4 @@ service:
       #exporters: [otlp_http/logs,debug/logs]
     profiles:
       receivers: [otlp]
-      exporters: [otlp/profiles]
+      exporters: [otlp_grpc/profiles]


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector/issues/14396 for background.

Note: the `otlp` in the receiver section is OK, as it's a single component supporting both gRPC and HTTP.