### PR TITLE
Fix GHCR publishing

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -14,7 +14,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
-  COSIGN_VERSION: v3.0.6
+  COSIGN_VERSION: v3.1.1
 
 jobs:
   build:
@@ -41,31 +41,46 @@ jobs:
         shell: bash
         run: echo "GIT_COMMIT_EPOCH=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
 
-      - name: Build and push GHCR image
-        id: push
-        uses: grafana/shared-workflows/actions/docker-build-push-image@34f27887c37cafe70d34af57dfc86b468a31b8c4 # docker-build-push-image/v0.3.3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-          SOURCE_DATE_EPOCH: ${{ env.GIT_COMMIT_EPOCH }}
         with:
-          context: docker
-          push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64
-          registries: ghcr
-          image-name: ${{ env.IMAGE_NAME }}
-          build-args: |
-            LGTM_VERSION=${{ github.ref_name }}
-          tags: |-
-            type=ref,event=branch
-            type=ref,event=pr
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |-
             org.opencontainers.image.ref.name=${{ github.ref_name }}
             org.opencontainers.image.revision=${{ github.sha }}
             vcs-ref=${{ github.sha }}
             version=${{ github.ref_name }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        env:
+          SOURCE_DATE_EPOCH: ${{ env.GIT_COMMIT_EPOCH }}
+        with:
+          annotations: ${{ steps.meta.outputs.annotations }}
+          build-args: |
+            LGTM_VERSION=${{ github.ref_name }}
+          cache-from: type=gha
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
+          context: docker/
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Generate artifact attestation
         if: github.event_name != 'pull_request'
@@ -85,5 +100,5 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
-          TAGS: ${{ steps.push.outputs.tags }}
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes "{}@${DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
 
     env:
       # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
-      COSIGN_VERSION: v3.0.6
+      COSIGN_VERSION: v3.1.1
 
     permissions:
       artifact-metadata: write

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,7 +47,7 @@ ARG TARGETARCH
 ENV TARGETARCH=${TARGETARCH}
 
 # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
-ARG COSIGN_VERSION=v3.0.6
+ARG COSIGN_VERSION=v3.1.1
 
 RUN ./install-cosign.sh $COSIGN_VERSION
 


### PR DESCRIPTION
- Fix GHCR publishing - the shared action does not support publishing to GHCR. It's been broken since 1st June ([workflows](https://github.com/grafana/docker-otel-lgtm/actions/workflows/ghcr-image-build-and-publish.yml?query=branch%3Amain)).
- Bump cosign to latest, 3.1.1.

Reverts #1427.
