### PR TITLE
Publish refactoring

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -24,6 +24,10 @@ jobs:
       group: "${{ github.workflow }}-${{ github.sha }}"
       cancel-in-progress: false
 
+    environment:
+      name: release
+      url: ${{ format('{0}/{1}/pkgs/container/{2}', github.server_url, github.repository, 'docker-otel-lgtm') }}
+
     permissions:
       artifact-metadata: write
       attestations: write
@@ -38,8 +42,9 @@ jobs:
           persist-credentials: false
 
       - name: Get Git commit timestamp
+        id: get-commit-timestamp
         shell: bash
-        run: echo "GIT_COMMIT_EPOCH=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
+        run: echo "git-commit-epoch=$(git log -1 --pretty=%ct)" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -69,7 +74,7 @@ jobs:
         id: push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         env:
-          SOURCE_DATE_EPOCH: ${{ env.GIT_COMMIT_EPOCH }}
+          SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.git-commit-epoch }}
         with:
           annotations: ${{ steps.meta.outputs.annotations }}
           build-args: |
@@ -90,6 +95,17 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
 
+      - name: Verify attestations
+        if: github.event_name != 'pull_request'
+        shell: bash
+        env:
+          CONTAINER_IMAGE_DIGEST: ${{ format('oci://{0}/{1}@{2}', env.REGISTRY, env.IMAGE_NAME, steps.push.outputs.digest) }}
+          CONTAINER_IMAGE_LABEL: ${{ format('oci://{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name == github.event.repository.default_branch && github.event.repository.default_branch || 'latest') }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh attestation verify --repo "${GITHUB_REPOSITORY}" "${CONTAINER_IMAGE_DIGEST}" || exit 1
+          gh attestation verify --repo "${GITHUB_REPOSITORY}" "${CONTAINER_IMAGE_LABEL}" || exit 1
+
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -102,3 +118,15 @@ jobs:
           DIGEST: ${{ steps.push.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes "{}@${DIGEST}"
+
+      - name: Verify container image signatures
+        if: github.event_name != 'pull_request'
+        shell: bash
+        env:
+          CERTIFICATE_IDENTITY: ${{ format('{0}/{1}', github.server_url, github.workflow_ref) }}
+          CERTIFICATE_OIDC_ISSUER: "https://token.actions.githubusercontent.com"
+          CONTAINER_IMAGE_DIGEST: ${{ format('{0}/{1}@{2}', env.REGISTRY, env.IMAGE_NAME, steps.push.outputs.digest) }}
+          CONTAINER_IMAGE_LABEL: ${{ format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name == github.event.repository.default_branch && github.event.repository.default_branch || 'latest') }}
+        run: |
+          cosign verify "${CONTAINER_IMAGE_DIGEST}" --certificate-identity "${CERTIFICATE_IDENTITY}" --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" || exit 1
+          cosign verify "${CONTAINER_IMAGE_LABEL}" --certificate-identity "${CERTIFICATE_IDENTITY}" --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" || exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,14 +33,15 @@ jobs:
           persist-credentials: false
 
       - name: Get Git commit timestamp
+        id: get-commit-timestamp
         shell: bash
-        run: echo "GIT_COMMIT_EPOCH=$(git log -1 --pretty=%ct)" >> "${GITHUB_ENV}"
+        run: echo "git-commit-epoch=$(git log -1 --pretty=%ct)" >> "${GITHUB_OUTPUT}"
 
       - id: push-to-dockerhub
         uses: grafana/shared-workflows/actions/docker-build-push-image@b3d136565946d8788dd6812881fb0fb2fe14bacb # docker-build-push-image/v0.2.0
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-          SOURCE_DATE_EPOCH: ${{ env.GIT_COMMIT_EPOCH }}
+          SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.git-commit-epoch }}
         with:
           dockerhub-repository: grafana/otel-lgtm
           context: docker


### PR DESCRIPTION
Changes cherry-picked from #1455 and #1467:

- Use output instead of env for `SOURCE_DATE_EPOCH,
- Verify attestations and signatures.
- Associate ghcr publishing with an environment.
