### PR TITLE
Update container scan workflow

### DIFF
--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -27,6 +27,7 @@ jobs:
       cancel-in-progress: false
 
     permissions:
+      packages: read
       security-events: write
 
     strategy:

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   scan-image:
+    name: ${{ format('Scan {0} container image', matrix.repository) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     if: github.event.repository.fork == false
@@ -28,11 +29,20 @@ jobs:
     permissions:
       security-events: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image-ref: "grafana/otel-lgtm:latest"
+            repository: "DockerHub"
+          - image-ref: "ghcr.io/grafana/docker-otel-lgtm:${{ github.event.repository.default_branch }}"
+            repository: "GHCR"
+
     steps:
       - name: Run Trivy (SARIF)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.TRIVY_IMAGE_REF }}
+          image-ref: ${{ matrix.image-ref }}
           format: "sarif"
           ignore-unfixed: true
           limit-severities-for-sarif: true
@@ -46,9 +56,9 @@ jobs:
           sarif_file: "trivy.sarif"
 
       - name: Run Trivy (JSON)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.TRIVY_IMAGE_REF }}
+          image-ref: ${{ matrix.image-ref }}
           format: "json"
           ignore-unfixed: true
           output: "trivy.json"

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -23,7 +23,7 @@ jobs:
     if: github.event.repository.fork == false
 
     concurrency:
-      group: ${{ github.workflow }}
+      group: ${{ format('{0}-{1}', github.workflow, matrix.repository) }}
       cancel-in-progress: false
 
     permissions:


### PR DESCRIPTION
We can use Trivy's GitHub Actions again.

- Use the latest version of trivy.
- Scan images in both DockerHub and GHCR.


Tested [here](https://github.com/grafana/docker-otel-lgtm/actions/runs/27831578560).
