### PR TITLE
Skip deployment in PRs

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -26,6 +26,7 @@ jobs:
 
     environment:
       name: release
+      deployment: ${{ github.event_name != 'pull_request' }}
       url: ${{ format('{0}/{1}/pkgs/container/{2}', github.server_url, github.repository, 'docker-otel-lgtm') }}
 
     permissions:


### PR DESCRIPTION
Do not create a "deployment" for the release environment in pull requests.

Nothing is actually deployed, but it creates this otherwise:

<img width="389" height="52" alt="image" src="https://github.com/user-attachments/assets/0d4ba7b1-31f9-45c8-bd80-52d45f0dd86e" />
