### PR TITLE
Fix DockerHub publishing

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out
         with:
           persist-credentials: false
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0 # needed for merge-base used in lint:links-in-modified-files

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           filter: "tree:0"
           persist-credentials: false

--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -63,6 +63,7 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.git-commit-epoch }}
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |-
@@ -118,7 +119,8 @@ jobs:
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes "{}@${DIGEST}"
+        run: |
+          echo "${TAGS}" | xargs -I {} cosign sign --yes "{}@${DIGEST}" --annotations "ref=${GITHUB_SHA}" --annotations "repo=${GITHUB_REPOSITORY}" --annotations "workflow=${GITHUB_WORKFLOW}"
 
       - name: Verify container image signatures
         if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       registry: ${{ env.REGISTRY }}
       sign-target: ${{ format('{0}@{1}', steps.publish.outputs.images, steps.publish.outputs.digest) }}
       tags: ${{ steps.publish.outputs.tags }}
+      version: ${{ steps.get-version.outputs.version }}
 
     permissions:
       contents: read
@@ -49,6 +50,11 @@ jobs:
         id: get-commit-timestamp
         shell: bash
         run: echo "git-commit-epoch=$(git log -1 --pretty=%ct)" >> "${GITHUB_OUTPUT}"
+
+      - name: Get version from tag
+        id: get-version
+        shell: bash
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish to GAR
         id: publish
@@ -129,7 +135,7 @@ jobs:
         env:
           CONTAINER_IMAGE_DIGEST: ${{ format('oci://{0}/{1}@{2}', env.REGISTRY, needs.release.outputs.image, needs.release.outputs.digest) }}
           CONTAINER_IMAGE_FLOATING: ${{ format('oci://{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, env.FLOATING_LABEL) }}
-          CONTAINER_IMAGE_LABEL: ${{ format('oci://{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, github.ref_name) }}
+          CONTAINER_IMAGE_LABEL: ${{ format('oci://{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, needs.release.outputs.version) }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SIGNER_WORKFLOW_REF: "grafana/shared-workflows/.github/workflows/sign-and-attest.yml"
         run: |
@@ -152,7 +158,7 @@ jobs:
           CERTIFICATE_OIDC_ISSUER: "https://token.actions.githubusercontent.com"
           CONTAINER_IMAGE_DIGEST: ${{ format('{0}/{1}@{2}', env.REGISTRY, needs.release.outputs.image, needs.release.outputs.digest) }}
           CONTAINER_IMAGE_FLOATING: ${{ format('{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, env.FLOATING_LABEL) }}
-          CONTAINER_IMAGE_LABEL: ${{ format('{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, github.ref_name) }}
+          CONTAINER_IMAGE_LABEL: ${{ format('{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, needs.release.outputs.version) }}
         run: |
           cosign verify "${CONTAINER_IMAGE_DIGEST}" --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEX}" --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" --certificate-github-workflow-repository "${GITHUB_REPOSITORY}" || exit 1
           cosign verify "${CONTAINER_IMAGE_LABEL}" --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEX}" --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" --certificate-github-workflow-repository "${GITHUB_REPOSITORY}" || exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
   sign:
     needs: release
     permissions:
+      artifact-metadata: write
       attestations: write
       contents: read
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,29 +6,46 @@ on:
     tags:
       - "v*.*.*"
 
+env:
+  # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
+  COSIGN_VERSION: v3.1.1
+
 permissions: {}
 
 jobs:
   release:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     concurrency:
       group: "${{ github.workflow }}-${{ github.ref }}"
       cancel-in-progress: false
 
     env:
-      # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
-      COSIGN_VERSION: v3.1.1
+      ENVIRONMENT: prod
+      IMAGE: otel-lgtm
+      IMAGE_NAME: grafana/otel-lgtm
+      REGISTRY: us-docker.pkg.dev
+      REPOSITORY: ${{ format('dockerhub-{0}-prod-mirror', github.event.repository.name) }}
+
+    environment:
+      name: release
+      url: "https://hub.docker.com/r/grafana/otel-lgtm"
+
+    outputs:
+      digest: ${{ steps.publish.outputs.digest }}
+      image: ${{ env.IMAGE_NAME }}
+      registry: ${{ env.REGISTRY }}
+      sign-target: ${{ format('{0}@{1}', steps.publish.outputs.images, steps.publish.outputs.digest) }}
+      tags: ${{ steps.publish.outputs.tags }}
 
     permissions:
-      artifact-metadata: write
-      attestations: write
       contents: read
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -37,17 +54,21 @@ jobs:
         shell: bash
         run: echo "git-commit-epoch=$(git log -1 --pretty=%ct)" >> "${GITHUB_OUTPUT}"
 
-      - id: push-to-dockerhub
-        uses: grafana/shared-workflows/actions/docker-build-push-image@b3d136565946d8788dd6812881fb0fb2fe14bacb # docker-build-push-image/v0.2.0
+      - name: Publish to GAR
+        id: publish
+        uses: grafana/shared-workflows/actions/docker-build-push-image@c66d74df41cf4ed28a90da1d91c263f9d1609a21 # docker-build-push-image/v0.3.4
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
           SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.git-commit-epoch }}
         with:
-          dockerhub-repository: grafana/otel-lgtm
           context: docker
+          gar-environment: ${{ env.ENVIRONMENT }}
+          gar-image: ${{ env.IMAGE }}
+          gar-registry: ${{ env.REGISTRY }}
+          gar-repository: ${{ env.REPOSITORY }}
           push: true
           platforms: linux/amd64,linux/arm64
-          registries: "dockerhub"
+          registries: "gar"
           build-args: |
             LGTM_VERSION=${{ github.ref_name }}
           tags: |-
@@ -59,20 +80,82 @@ jobs:
             vcs-ref=${{ github.sha }}
             version=${{ github.ref_name }}
 
-      - name: Generate artifact attestation
-        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+  sign:
+    needs: release
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    # TODO Needs to be a tagged version
+    uses: grafana/shared-workflows/.github/workflows/sign-and-attest.yml@24c4b83e50e74fce9871480681d123fd3c68f4f4 # main
+    with:
+      # TODO Needs https://github.com/grafana/shared-workflows/pull/2156
+      #cosign-version: ${{ env.COSIGN_VERSION }}
+      image: ${{ needs.release.outputs.sign-target }}
+      registry: ${{ needs.release.outputs.registry }}
+
+  wait-for-mirror:
+    needs: release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
+    concurrency:
+      group: ${{ format('{0}-{1}', github.workflow, needs.release.outputs.digest) }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Wait for DockerHub mirroring
+        uses: grafana/shared-workflows/actions/wait-for-docker-publish@cd185787ec303639a71383384e1b0d424b7422fb # wait-for-docker-publish/v0.2.0
         with:
-          push-to-registry: true
-          subject-name: docker.io/grafana/otel-lgtm
-          subject-digest: ${{ steps.push-to-dockerhub.outputs.digest }}
+          image: ${{ format('{0}@{1}', needs.release.outputs.image, needs.release.outputs.digest) }}
+          timeout: "15m"
+
+  verify:
+    needs: [release, sign, wait-for-mirror]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    concurrency:
+      group: ${{ format('{0}-{1}', github.workflow, needs.release.outputs.digest) }}
+      cancel-in-progress: false
+
+    env:
+      FLOATING_LABEL: latest
+      REGISTRY: docker.io
+
+    permissions:
+      artifact-metadata: read
+      attestations: read
+      contents: read
+
+    steps:
+      - name: Verify attestations
+        env:
+          CONTAINER_IMAGE_DIGEST: ${{ format('oci://{0}/{1}@{2}', env.REGISTRY, needs.release.outputs.image, needs.release.outputs.digest) }}
+          CONTAINER_IMAGE_FLOATING: ${{ format('oci://{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, env.FLOATING_LABEL) }}
+          CONTAINER_IMAGE_LABEL: ${{ format('oci://{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, github.ref_name) }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGNER_WORKFLOW_REF: "grafana/shared-workflows/.github/workflows/sign-and-attest.yml"
+        run: |
+          gh attestation verify --repo "${GITHUB_REPOSITORY}" --signer-workflow "${SIGNER_WORKFLOW_REF}" "${CONTAINER_IMAGE_DIGEST}" || exit 1
+          gh attestation verify --repo "${GITHUB_REPOSITORY}" --signer-workflow "${SIGNER_WORKFLOW_REF}" "${CONTAINER_IMAGE_FLOATING}" || exit 1
+          gh attestation verify --repo "${GITHUB_REPOSITORY}" --signer-workflow "${SIGNER_WORKFLOW_REF}" "${CONTAINER_IMAGE_LABEL}" || exit 1
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: ${{ env.COSIGN_VERSION }}
 
-      - name: Sign container images
+      - name: Verify container image signatures
+        shell: bash
         env:
-          DIGEST: ${{ steps.push-to-dockerhub.outputs.digest }}
-          TAGS: ${{ steps.push-to-dockerhub.outputs.tags }}
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes "{}@${DIGEST}"
+          CERTIFICATE_IDENTITY: ${{ format('{0}/{1}', github.server_url, github.workflow_ref) }}
+          CERTIFICATE_IDENTITY_REGEX: "^https://github\\.com/grafana/shared-workflows/\\.github/workflows/sign-and-attest\\.yml@"
+          CERTIFICATE_OIDC_ISSUER: "https://token.actions.githubusercontent.com"
+          CONTAINER_IMAGE_DIGEST: ${{ format('{0}/{1}@{2}', env.REGISTRY, needs.release.outputs.image, needs.release.outputs.digest) }}
+          CONTAINER_IMAGE_FLOATING: ${{ format('{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, env.FLOATING_LABEL) }}
+          CONTAINER_IMAGE_LABEL: ${{ format('{0}/{1}:{2}', env.REGISTRY, needs.release.outputs.image, github.ref_name) }}
+        run: |
+          cosign verify "${CONTAINER_IMAGE_DIGEST}" --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEX}" --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" --certificate-github-workflow-repository "${GITHUB_REPOSITORY}" || exit 1
+          cosign verify "${CONTAINER_IMAGE_LABEL}" --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEX}" --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" --certificate-github-workflow-repository "${GITHUB_REPOSITORY}" || exit 1
+          cosign verify "${CONTAINER_IMAGE_FLOATING}" --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEX}" --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" --certificate-github-workflow-repository "${GITHUB_REPOSITORY}" || exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
     tags:
       - "v*.*.*"
 
-env:
-  # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
-  COSIGN_VERSION: v3.1.1
-
 permissions: {}
 
 jobs:
@@ -87,10 +83,10 @@ jobs:
       contents: read
       id-token: write
     # TODO Needs to be a tagged version
-    uses: grafana/shared-workflows/.github/workflows/sign-and-attest.yml@24c4b83e50e74fce9871480681d123fd3c68f4f4 # main
+    uses: grafana/shared-workflows/.github/workflows/sign-and-attest.yml@f881046c6f637c8167d8b6c9f9185688e3cfe1d3 # main
     with:
-      # TODO Needs https://github.com/grafana/shared-workflows/pull/2156
-      #cosign-version: ${{ env.COSIGN_VERSION }}
+      # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
+      cosign-version: v3.1.1
       image: ${{ needs.release.outputs.sign-target }}
       registry: ${{ needs.release.outputs.registry }}
 
@@ -105,7 +101,7 @@ jobs:
 
     steps:
       - name: Wait for DockerHub mirroring
-        uses: grafana/shared-workflows/actions/wait-for-docker-publish@cd185787ec303639a71383384e1b0d424b7422fb # wait-for-docker-publish/v0.2.0
+        uses: grafana/shared-workflows/actions/wait-for-docker-publish@a2718cb69dbc55c16d5db1ee9fc0fd1d052079fa # wait-for-docker-publish/v0.3.0
         with:
           image: ${{ format('{0}@{1}', needs.release.outputs.image, needs.release.outputs.digest) }}
           timeout: "15m"
@@ -143,6 +139,9 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        env:
+          # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
+          COSIGN_VERSION: v3.1.1
         with:
           cosign-release: ${{ env.COSIGN_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,6 @@ jobs:
       - name: Verify container image signatures
         shell: bash
         env:
-          CERTIFICATE_IDENTITY: ${{ format('{0}/{1}', github.server_url, github.workflow_ref) }}
           CERTIFICATE_IDENTITY_REGEX: "^https://github\\.com/grafana/shared-workflows/\\.github/workflows/sign-and-attest\\.yml@"
           CERTIFICATE_OIDC_ISSUER: "https://token.actions.githubusercontent.com"
           CONTAINER_IMAGE_DIGEST: ${{ format('{0}/{1}@{2}', env.REGISTRY, needs.release.outputs.image, needs.release.outputs.digest) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,6 @@ jobs:
       attestations: write
       contents: read
       id-token: write
-    # TODO Needs to be a tagged version
     uses: grafana/shared-workflows/.github/workflows/sign-and-attest.yml@f881046c6f637c8167d8b6c9f9185688e3cfe1d3 # main
     with:
       # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign

--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/README.md
+++ b/README.md
@@ -357,16 +357,17 @@ Each example uses a different application port
 
 ## Verifying Container Image Signatures
 
-The container images that are published are signed using [cosign][cosign]. You
-can verify the signatures using a command similar to the following example:
+The container images that are published are signed using [cosign][cosign] v3+.
+You can verify the signatures using a command similar to the following example:
 
 ```sh
-VERSION="0.11.16"
+VERSION="0.29.0"
 IMAGE="docker.io/grafana/otel-lgtm:${VERSION}"
-IDENTITY="https://github.com/grafana/docker-otel-lgtm/.github/workflows/release.yml@refs/tags/v${VERSION}"
-OIDC_ISSUER="https://token.actions.githubusercontent.com"
+CERTIFICATE_IDENTITY_REGEX="^https://github\.com/grafana/shared-workflows/\.github/workflows/sign-and-attest\.yml@"
+CERTIFICATE_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+CERTIFICATE_REPO="grafana/docker-otel-lgtm"
 
-cosign verify ${IMAGE} --certificate-identity ${IDENTITY} --certificate-oidc-issuer ${OIDC_ISSUER}
+cosign verify "${IMAGE}" --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEX}" --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" --certificate-github-workflow-repository "${CERTIFICATE_REPO}"
 ```
 
 It is also possible to verify the signatures of images from our continuous integration
@@ -376,10 +377,35 @@ that are published to the [GitHub Container Registry][ghcr]. For example for the
 VERSION="main"
 IMAGE="ghcr.io/grafana/docker-otel-lgtm:${VERSION}"
 WORKFLOW="ghcr-image-build-and-publish.yml"
-IDENTITY="https://github.com/grafana/docker-otel-lgtm/.github/workflows/${WORKFLOW}@refs/heads/${VERSION}"
-OIDC_ISSUER="https://token.actions.githubusercontent.com"
+CERTIFICATE_IDENTITY="https://github.com/grafana/docker-otel-lgtm/.github/workflows/${WORKFLOW}@refs/heads/${VERSION}"
+CERTIFICATE_OIDC_ISSUER="https://token.actions.githubusercontent.com"
 
-cosign verify ${IMAGE} --certificate-identity ${IDENTITY} --certificate-oidc-issuer ${OIDC_ISSUER}
+cosign verify "${IMAGE}" --certificate-identity "${CERTIFICATE_IDENTITY}" --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}"
+```
+
+## Verifying Container Image Attestations
+
+The container images that are published are also [attested][github-attestation]. You
+can verify the attestations using the [GitHub CLI][gh-cli] as shown in the following example:
+
+```sh
+VERSION="0.29.0"
+IMAGE="oci://docker.io/grafana/otel-lgtm:${VERSION}"
+REPOSITORY="grafana/docker-otel-lgtm"
+SIGNER_WORKFLOW="grafana/shared-workflows/.github/workflows/sign-and-attest.yml"
+
+gh attestation verify --repo "${REPOSITORY}" "${IMAGE}" --signer-workflow "${SIGNER_WORKFLOW}"
+```
+
+It is also possible to verify the attestations of images from our continuous integration
+that are published to the [GitHub Container Registry][ghcr]. For example for the `main` branch:
+
+```sh
+VERSION="main"
+REPOSITORY="grafana/docker-otel-lgtm"
+IMAGE="oci://ghcr.io/${REPOSITORY}:${VERSION}"
+
+gh attestation verify --repo "${REPOSITORY}" "${IMAGE}"
 ```
 
 ## AI Tool Integration (MCP)
@@ -419,6 +445,8 @@ Paste the JSON into your AI tool's MCP configuration. See [docs/mcp-integration.
 [docker-pulls]: https://img.shields.io/docker/pulls/grafana/otel-lgtm?logo=docker&label=pulls
 [examples]: examples/
 [ghcr]: https://github.com/grafana/docker-otel-lgtm/pkgs/container/docker-otel-lgtm
+[gh-cli]: https://cli.github.com/ "GitHub CLI"
+[github-attestation]: https://docs.github.com/actions/concepts/security/artifact-attestations
 [grafana-env-overrides]: https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables
 [grafana-preinstall-plugins]: https://grafana.com/docs/grafana/latest/setup-grafana/configure-docker/#install-plugins-in-the-docker-container
 [java-example]: examples/java/


### PR DESCRIPTION
Fix DockerHub releases by publishing to GAR, which mirrors the image and the cosign signatures to DockerHub.

~~Depends on https://github.com/grafana/shared-workflows/pull/2156 and https://github.com/grafana/shared-workflows/pull/2157.~~

Tested in #1467 ([successful workflow](https://github.com/grafana/docker-otel-lgtm/actions/runs/29101638953) which published [this image](https://hub.docker.com/layers/dwyliegrafana/otel-lgtm/latest/images/sha256-b1cf058bcc730c8a5686bfa9b4cd2e07ca583a6ea7408ac4661e6c2c460d4847))

Supersedes #1455.
