### PR TITLE
fix: prevent interactive shutdown hangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ You can enable logging in the .env file for troubleshooting:
 
 This has nothing to do with any application logs, which are collected by OpenTelemetry.
 
+### Configure the shutdown timeout
+
+The container forwards `SIGTERM` and `SIGINT` to every backend and waits up to five seconds
+for a graceful shutdown. Set `LGTM_SHUTDOWN_TIMEOUT_SECONDS` to change this grace period.
+Any process still running after the timeout is forcefully stopped.
+
 ### Enable OBI (eBPF auto-instrumentation)
 
 [OpenTelemetry eBPF Instrumentation (OBI)][obi] uses eBPF to automatically generate traces and

--- a/docker/run-all.bats
+++ b/docker/run-all.bats
@@ -18,7 +18,7 @@ setup() {
 		run-pyroscope.sh; do
 		cat >"$TESTDIR/$script" <<'SCRIPT'
 #!/usr/bin/env bash
-if [[ ${STUB_IGNORE_TERM:-false} == "true" ]]; then
+if [[ "${STUB_IGNORE_TERM:-false}" == "true" ]]; then
 	trap '' TERM
 fi
 exec sleep 60

--- a/docker/run-all.bats
+++ b/docker/run-all.bats
@@ -18,7 +18,10 @@ setup() {
 		run-pyroscope.sh; do
 		cat >"$TESTDIR/$script" <<'SCRIPT'
 #!/usr/bin/env bash
-sleep 60
+if [[ ${STUB_IGNORE_TERM:-false} == "true" ]]; then
+	trap '' TERM
+fi
+exec sleep 60
 SCRIPT
 		chmod +x "$TESTDIR/$script"
 	done
@@ -100,6 +103,18 @@ run_run_all() {
 			timeout 3s bash ./run-all.sh
 }
 
+run_run_all_with_stubborn_children() {
+	cd "$TESTDIR" || return 1
+	PATH="$TESTDIR:$PATH" \
+		LGTM_CONFIG_DIR="$CONFIGDIR" \
+		GRAFANA_SA_TOKEN_FILE="$TOKENFILE" \
+		LGTM_VERSION=latest \
+		CONTAINER_RUNTIME=docker \
+		LGTM_SHUTDOWN_TIMEOUT_SECONDS=0.1 \
+		STUB_IGNORE_TERM=true \
+			timeout --preserve-status --signal=TERM --kill-after=2s 1s bash ./run-all.sh
+}
+
 run_mcp_case() {
 	local tempo_enabled=$1
 	local sa_mode=$2
@@ -137,6 +152,12 @@ assert_file_contains() {
 
 assert_file_not_contains() {
 	! grep -Fq "$2" "$1"
+}
+
+@test "shutdown force stops children after the grace period" {
+	run run_run_all_with_stubborn_children
+	[ "$status" -eq 0 ]
+	assert_contains "Shutting down..."
 }
 
 @test "docs URL uses main for latest" {

--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -2,13 +2,30 @@
 
 echo "Starting grafana/otel-lgtm ${LGTM_VERSION}"
 
-# Graceful shutdown: forward SIGTERM/SIGINT to all background jobs
+# Graceful shutdown: forward SIGTERM/SIGINT to all background jobs.
 shutdown() {
+	# Avoid re-entering the handler if another signal arrives while waiting.
+	trap - SIGTERM SIGINT
 	echo "Shutting down..."
-	# Send SIGTERM to all background jobs (the wrapper scripts exec the
-	# server process, so these PIDs are the actual server processes)
-	jobs -p | xargs -r kill 2>/dev/null
-	wait
+
+	local pids=()
+	mapfile -t pids < <(jobs -pr)
+	if ((${#pids[@]} == 0)); then
+		exit 0
+	fi
+
+	# The wrapper scripts exec the server processes, so these are the server
+	# PIDs. Give them time to stop cleanly before forcing any stragglers down.
+	kill -TERM "${pids[@]}" 2>/dev/null || true
+	(
+		sleep "${LGTM_SHUTDOWN_TIMEOUT_SECONDS:-5}"
+		kill -KILL "${pids[@]}" 2>/dev/null || true
+	) &
+	local watchdog_pid=$!
+
+	wait "${pids[@]}" 2>/dev/null || true
+	kill "$watchdog_pid" 2>/dev/null || true
+	wait "$watchdog_pid" 2>/dev/null || true
 	exit 0
 }
 trap shutdown SIGTERM SIGINT


### PR DESCRIPTION
## Summary
- make the shutdown handler non-reentrant
- bound graceful shutdown to five seconds by default, then force-stop remaining processes
- allow the grace period to be configured with `LGTM_SHUTDOWN_TIMEOUT_SECONDS`
- add regression coverage with backend stubs that ignore `SIGTERM`

## Validation
- `bats docker/run-otelcol.bats docker/run-all.bats run-lgtm.bats` (33 tests passed)
- `flint run shellcheck shfmt rumdl`
- `flint run editorconfig-checker typos`
- `git diff --check`

A local container run was not available because this environment has no Docker or Podman runtime. The regression test exercises the previously unbounded wait and verifies the watchdog escalation path.

Fixes #1270