### PR TITLE
Add EXPOSE directives

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -168,4 +168,17 @@ LABEL cpe=""
 LABEL io.buildah.version=""
 LABEL release=""
 
+# Grafana
+EXPOSE 3000
+
+# Pyroscope
+EXPOSE 4040
+
+# OpenTelemetry Collector
+EXPOSE 4317
+EXPOSE 4318
+
+# Prometheus
+EXPOSE 9090
+
 CMD ["/otel-lgtm/run-all.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -171,6 +171,9 @@ LABEL release=""
 # Grafana
 EXPOSE 3000
 
+# Tempo
+EXPOSE 3200
+
 # Pyroscope
 EXPOSE 4040
 


### PR DESCRIPTION
Use `EXPOSE` to document the container ports.

Resolves #1285.
