### PR TITLE
Update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,9 +2,9 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "config:best-practices",
-    "config:recommended",
     "customManagers:dockerfileVersions",
     "customManagers:githubActionsVersions",
+    "helpers:pinGitHubActionDigestsToSemver",
     "github>grafana/flint#v0.22.10"
   ],
   branchPrefix: "grafanarenovatebot/",


### PR DESCRIPTION
- Add `helpers:pinGitHubActionDigestsToSemver` to ensure major upgrades always use a full version comment.
- Remove redundant `config:recommended` ([`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices) extends it).
