### PR TITLE
docs: add Nomad (+ Consul) example for otel-lgtm

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -8,6 +8,10 @@
       "packageName": "grafana/loki",
       "datasource": "github-releases"
     },
+    "grafana/otel-lgtm": {
+      "packageName": "grafana/otel-lgtm",
+      "datasource": "docker"
+    },
     "obi": {
       "packageName": "open-telemetry/opentelemetry-ebpf-instrumentation",
       "datasource": "github-releases"
@@ -313,6 +317,16 @@
     "go.mod": {
       "gomod": [
         "go"
+      ]
+    },
+    "nomad/README.md": {
+      "regex": [
+        "grafana/otel-lgtm"
+      ]
+    },
+    "nomad/lgtm.nomad.hcl": {
+      "regex": [
+        "grafana/otel-lgtm"
       ]
     },
     "mise.toml": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,7 @@
       matchPackageNames: [
         "grafana/grafana",
         "grafana/loki",
+        "grafana/otel-lgtm",
         "grafana/pyroscope",
         "grafana/tempo",
         "open-telemetry/opentelemetry-collector-releases",
@@ -71,6 +72,17 @@
       matchStrings: [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?(?: packageName=(?<packageName>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s.+?_version=(?<currentValue>.+?)\\s"
       ]
+    },
+    {
+      customType: "regex",
+      description: "Update grafana/otel-lgtm image tag in the Nomad example",
+      managerFilePatterns: ["/nomad/README.md$/", "/nomad/lgtm.nomad.hcl$/"],
+      matchStrings: [
+        "docker\\.io/grafana/otel-lgtm:(?<currentValue>[\\w.-]+)"
+      ],
+      datasourceTemplate: "docker",
+      depNameTemplate: "grafana/otel-lgtm",
+      packageNameTemplate: "grafana/otel-lgtm"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -265,6 +265,15 @@ mise k8s-apply
 mise k8s-port-forward
 ```
 
+## Run lgtm with Nomad
+
+See [`nomad/`](nomad/) for a Nomad job spec (optional Consul service registration)
+that mirrors the Kubernetes example and `run-lgtm.sh` ports.
+
+```sh
+nomad job run nomad/lgtm.nomad.hcl
+```
+
 ## Send OpenTelemetry Data
 
 There's no need to configure anything: the Docker image works with OpenTelemetry's defaults.

--- a/nomad/README.md
+++ b/nomad/README.md
@@ -1,0 +1,54 @@
+# Run lgtm with Nomad (and Consul)
+
+This directory contains a Nomad job that runs the `grafana/otel-lgtm` image,
+mirroring the ports used by [`run-lgtm.sh`](../run-lgtm.sh) and
+[`k8s/lgtm.yaml`](../k8s/lgtm.yaml).
+
+> [!IMPORTANT]
+> Intended for development, demo, and testing only — not for production.
+
+## Prerequisites
+
+- [Nomad](https://developer.hashicorp.com/nomad) with the Docker task driver
+- Optional but recommended: [Consul](https://developer.hashicorp.com/consul) for
+  the job's `service` blocks (`provider = "consul"`)
+
+## Deploy
+
+```sh
+nomad job run nomad/lgtm.nomad.hcl
+```
+
+Override the image tag if needed:
+
+```sh
+nomad job run -var="image=docker.io/grafana/otel-lgtm:0.11.0" nomad/lgtm.nomad.hcl
+```
+
+## Access
+
+| Service    | URL / address         |
+|------------|-----------------------|
+| Grafana    | http://127.0.0.1:3000 |
+| OTLP gRPC  | 127.0.0.1:4317        |
+| OTLP HTTP  | http://127.0.0.1:4318 |
+| Prometheus | http://127.0.0.1:9090 |
+| Tempo      | http://127.0.0.1:3200 |
+| Pyroscope  | http://127.0.0.1:4040 |
+
+Default Grafana credentials: `admin` / `admin`.
+
+If Consul is enabled, services are registered as `lgtm-grafana`,
+`lgtm-otel-http`, `lgtm-otel-grpc`, and `lgtm-prometheus`.
+
+## Persistence
+
+The job uses Nomad `ephemeral_disk` (similar to Kubernetes `emptyDir`). Data is
+kept for the life of the allocation. For durable host paths, add Nomad
+`host_volume` mounts for `/data/grafana`, `/data/prometheus`, `/data/loki`,
+`/data/tempo`, and `/data/pyroscope` (see `run-lgtm.sh` volume layout).
+
+## Without Consul
+
+If you are not running Consul, change each `service` block's `provider` to
+`"nomad"` (Nomad native service discovery) or remove the `service` blocks.

--- a/nomad/README.md
+++ b/nomad/README.md
@@ -27,14 +27,14 @@ nomad job run -var="image=docker.io/grafana/otel-lgtm:0.30.2" nomad/lgtm.nomad.h
 
 ## Access
 
-| Service    | URL / address         |
-|------------|-----------------------|
-| Grafana    | http://127.0.0.1:3000 |
-| OTLP gRPC  | 127.0.0.1:4317        |
-| OTLP HTTP  | http://127.0.0.1:4318 |
-| Prometheus | http://127.0.0.1:9090 |
-| Tempo      | http://127.0.0.1:3200 |
-| Pyroscope  | http://127.0.0.1:4040 |
+| Service    | URL / address           |
+|------------|-------------------------|
+| Grafana    | `http://127.0.0.1:3000` |
+| OTLP gRPC  | `127.0.0.1:4317`        |
+| OTLP HTTP  | `http://127.0.0.1:4318` |
+| Prometheus | `http://127.0.0.1:9090` |
+| Tempo      | `http://127.0.0.1:3200` |
+| Pyroscope  | `http://127.0.0.1:4040` |
 
 Default Grafana credentials: `admin` / `admin`.
 

--- a/nomad/README.md
+++ b/nomad/README.md
@@ -22,7 +22,7 @@ nomad job run nomad/lgtm.nomad.hcl
 Override the image tag if needed:
 
 ```sh
-nomad job run -var="image=docker.io/grafana/otel-lgtm:0.11.0" nomad/lgtm.nomad.hcl
+nomad job run -var="image=docker.io/grafana/otel-lgtm:0.30.2" nomad/lgtm.nomad.hcl
 ```
 
 ## Access

--- a/nomad/lgtm.nomad.hcl
+++ b/nomad/lgtm.nomad.hcl
@@ -18,7 +18,7 @@
 
 variable "image" {
   type        = string
-  default     = "docker.io/grafana/otel-lgtm:latest"
+  default     = "docker.io/grafana/otel-lgtm:0.30.2"
   description = "otel-lgtm container image"
 }
 

--- a/nomad/lgtm.nomad.hcl
+++ b/nomad/lgtm.nomad.hcl
@@ -1,0 +1,121 @@
+# Nomad job for grafana/otel-lgtm (demo / testing only — not for production).
+# Mirrors k8s/lgtm.yaml and run-lgtm.sh ports.
+#
+# Prerequisites:
+#   - Nomad with Docker driver
+#   - Optional: Consul for service discovery (service blocks below)
+#
+# Deploy:
+#   nomad job run nomad/lgtm.nomad.hcl
+#
+# Access:
+#   Grafana:      http://127.0.0.1:3000  (admin/admin)
+#   OTLP gRPC:    127.0.0.1:4317
+#   OTLP HTTP:    127.0.0.1:4318
+#   Prometheus:   http://127.0.0.1:9090
+#   Tempo:        http://127.0.0.1:3200
+#   Pyroscope:    http://127.0.0.1:4040
+
+variable "image" {
+  type        = string
+  default     = "docker.io/grafana/otel-lgtm:latest"
+  description = "otel-lgtm container image"
+}
+
+job "lgtm" {
+  datacenters = ["dc1"]
+  type        = "service"
+
+  group "lgtm" {
+    count = 1
+
+    # Ephemeral disk for /data (similar to k8s emptyDir volumes).
+    ephemeral_disk {
+      size = 4096
+    }
+
+    network {
+      port "grafana" {
+        static = 3000
+        to     = 3000
+      }
+      port "tempo" {
+        static = 3200
+        to     = 3200
+      }
+      port "pyroscope" {
+        static = 4040
+        to     = 4040
+      }
+      port "otel_grpc" {
+        static = 4317
+        to     = 4317
+      }
+      port "otel_http" {
+        static = 4318
+        to     = 4318
+      }
+      port "prometheus" {
+        static = 9090
+        to     = 9090
+      }
+    }
+
+    task "lgtm" {
+      driver = "docker"
+
+      config {
+        image = var.image
+        ports = [
+          "grafana",
+          "tempo",
+          "pyroscope",
+          "otel_grpc",
+          "otel_http",
+          "prometheus",
+        ]
+      }
+
+      env {
+        GF_PATHS_DATA = "/data/grafana"
+      }
+
+      resources {
+        cpu    = 1000
+        memory = 2048
+      }
+
+      # Consul service registration (ignored if Consul is not available
+      # when using Nomad native service discovery — switch provider if needed).
+      service {
+        name     = "lgtm-grafana"
+        port     = "grafana"
+        provider = "consul"
+        check {
+          type     = "http"
+          path     = "/api/health"
+          interval = "10s"
+          timeout  = "2s"
+        }
+      }
+
+      service {
+        name     = "lgtm-otel-http"
+        port     = "otel_http"
+        provider = "consul"
+      }
+
+      service {
+        name     = "lgtm-otel-grpc"
+        port     = "otel_grpc"
+        provider = "consul"
+      }
+
+      service {
+        name     = "lgtm-prometheus"
+        port     = "prometheus"
+        provider = "consul"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `nomad/lgtm.nomad.hcl` job mirroring Docker/k8s ports for `grafana/otel-lgtm`
- Optional Consul service registration for Grafana/OTLP/Prometheus
- Document usage in `nomad/README.md` and root README

Fixes #586

## Test plan
- [ ] `nomad job validate nomad/lgtm.nomad.hcl` (or review HCL)
- [ ] `nomad job run nomad/lgtm.nomad.hcl` against a local Nomad+Docker setup
- [ ] Hit Grafana on :3000 and OTLP on :4317/:4318