### PR TITLE
Add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,3 +125,4 @@ made there, not elsewhere.
 Releases are automated weekly (Friday 09:00 UTC) via GitHub Actions if
 `docker/` has changed. Version auto-increments based on component changes.
 Releases are immutable once published.
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,4 @@ made there, not elsewhere.
 Releases are automated weekly (Friday 09:00 UTC) via GitHub Actions if
 `docker/` has changed. Version auto-increments based on component changes.
 Releases are immutable once published.
-
-## Security
-
-Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,4 +125,7 @@ made there, not elsewhere.
 Releases are automated weekly (Friday 09:00 UTC) via GitHub Actions if
 `docker/` has changed. Version auto-increments based on component changes.
 Releases are immutable once published.
-- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.
+
+## Security
+
+Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
