### PR TITLE
fix: correct shared workflow Renovate metadata

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,10 +47,6 @@
       enabled: false
     },
     {
-      matchPackageNames: ["grafana/shared-workflows"],
-      versioning: "regex:^(?<compatibility>[a-z-]+)-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$"
-    },
-    {
       extends: ["monorepo:dotnet"],
       description: ["Disable major version updates for .NET"],
       matchUpdateTypes: ["major"],

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Get GitHub token
         id: get-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
           github_app: grafana-otel-bot
           permission_set: default


### PR DESCRIPTION
## What changed

- Correct the `create-github-app-token` version comment to the component-prefixed tag.
- Remove the obsolete repository-local `grafana/shared-workflows` Renovate rule.

## Why

The bare `# v0.2.2` annotation was introduced in the workflow template and does not identify the shared-workflows monorepo component, so Renovate cannot reliably look up the action. This cleanup addresses the shared-workflows lookup warning tracked in [dependency dashboard issue #920](https://github.com/grafana/docker-otel-lgtm/issues/920). The central preset adjustment is tracked in [grafana-renovate-config PR #116](https://github.com/grafana/grafana-renovate-config/pull/116).

The pinned SHA was verified against `create-github-app-token/v0.2.2`. The Flint `github-actions` exclusion remains unchanged until the action metadata support is available.

## Validation

- `mise run lint:fix`
- `mise run lint`

Related to grafana/shared-workflows#2255
