### PR TITLE
fix: make service startup failures more prominent 

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,13 +168,13 @@ some users even in testing situations.
 Each backend supports a `*_EXTRA_ARGS` environment variable for passing additional
 CLI flags without modifying any files:
 
-| Backend                 | Env var                 | Example                                   |
-|-------------------------|-------------------------|-------------------------------------------|
-| Prometheus              | `PROMETHEUS_EXTRA_ARGS` | `--storage.tsdb.retention.time=90d`       |
-| Loki                    | `LOKI_EXTRA_ARGS`       | `--limits.retention-period=90d`           |
-| Tempo                   | `TEMPO_EXTRA_ARGS`      | `--query-frontend.mcp-server.enabled=true`|
-| Pyroscope               | `PYROSCOPE_EXTRA_ARGS`  |                                           |
-| OpenTelemetry Collector | `OTELCOL_EXTRA_ARGS`    |                                           |
+| Backend                 | Env var                 | Example                                                                                             |
+|-------------------------|-------------------------|-----------------------------------------------------------------------------------------------------|
+| Prometheus              | `PROMETHEUS_EXTRA_ARGS` | `--storage.tsdb.retention.time=90d`                                                                 |
+| Loki                    | `LOKI_EXTRA_ARGS`       | `-store.retention=90d -compactor.retention-enabled=true -compactor.delete-request-store=filesystem` |
+| Tempo                   | `TEMPO_EXTRA_ARGS`      | `--query-frontend.mcp-server.enabled=true`                                                          |
+| Pyroscope               | `PYROSCOPE_EXTRA_ARGS`  |                                                                                                     |
+| OpenTelemetry Collector | `OTELCOL_EXTRA_ARGS`    |                                                                                                     |
 
 For example, to set a 90-day retention period for Prometheus:
 

--- a/docker/run-all.bats
+++ b/docker/run-all.bats
@@ -160,6 +160,39 @@ assert_file_not_contains() {
 	assert_contains "Shutting down..."
 }
 
+@test "fails fast when a component exits before becoming ready" {
+	cat >"$TESTDIR/run-loki.sh" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 1
+SCRIPT
+	chmod +x "$TESTDIR/run-loki.sh"
+
+	cat >"$TESTDIR/curl" <<'SCRIPT'
+#!/usr/bin/env bash
+args="$*"
+
+if [[ "$args" == *"127.0.0.1:3100/ready"* ]]; then
+	printf '000'
+	exit 0
+fi
+
+if [[ "$args" == *"/ready"* ||
+	"$args" == *"/api/health"* ||
+	"$args" == *"/api/v1/status/runtimeinfo"* ]]; then
+	printf '200'
+	exit 0
+fi
+
+printf '{}'
+SCRIPT
+	chmod +x "$TESTDIR/curl"
+
+	run run_run_all
+	[ "$status" -eq 1 ]
+	assert_contains "Error: Loki exited before becoming ready."
+	assert_contains "Re-run with ENABLE_LOGS_LOKI=true (or ENABLE_LOGS_ALL=true) to see its output."
+}
+
 @test "docs URL uses main for latest" {
 	local expected="https://github.com/grafana/docker-otel-lgtm/blob/main/docs/mcp-integration.md"
 	run run_run_all latest

--- a/docker/run-all.bats
+++ b/docker/run-all.bats
@@ -154,6 +154,10 @@ assert_file_not_contains() {
 	! grep -Fq "$2" "$1"
 }
 
+assert_process_stopped() {
+	! kill -0 "$1" 2>/dev/null
+}
+
 @test "shutdown force stops children after the grace period" {
 	run run_run_all_with_stubborn_children
 	[ "$status" -eq 0 ]
@@ -166,6 +170,18 @@ assert_file_not_contains() {
 exit 1
 SCRIPT
 	chmod +x "$TESTDIR/run-loki.sh"
+
+	# A well-behaved component that should be stopped (not orphaned) once
+	# the startup failure is detected. It records its own PID, then execs
+	# (like the real wrapper scripts) so a bash trap wouldn't fire anyway -
+	# the check below relies on the process itself no longer existing.
+	local pidfile="$TESTDIR/grafana.pid"
+	cat >"$TESTDIR/run-grafana.sh" <<SCRIPT
+#!/usr/bin/env bash
+echo \$\$ >"${pidfile}"
+exec sleep 60
+SCRIPT
+	chmod +x "$TESTDIR/run-grafana.sh"
 
 	cat >"$TESTDIR/curl" <<'SCRIPT'
 #!/usr/bin/env bash
@@ -191,6 +207,8 @@ SCRIPT
 	[ "$status" -eq 1 ]
 	assert_contains "Error: Loki exited before becoming ready."
 	assert_contains "Re-run with ENABLE_LOGS_LOKI=true (or ENABLE_LOGS_ALL=true) to see its output."
+	assert_has_file "$pidfile"
+	assert_process_stopped "$(cat "$pidfile")"
 }
 
 @test "docs URL uses main for latest" {

--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -2,16 +2,15 @@
 
 echo "Starting grafana/otel-lgtm ${LGTM_VERSION}"
 
-# Graceful shutdown: forward SIGTERM/SIGINT to all background jobs.
-shutdown() {
-	# Avoid re-entering the handler if another signal arrives while waiting.
-	trap - SIGTERM SIGINT
-	echo "Shutting down..."
-
+# Stop any still-running backgrounded components, giving them time to stop
+# cleanly before forcing any stragglers down. Used both for SIGTERM/SIGINT
+# and when a component fails to start, so a startup failure doesn't leak
+# orphaned processes.
+stop_components() {
 	local pids=()
 	mapfile -t pids < <(jobs -pr)
 	if ((${#pids[@]} == 0)); then
-		exit 0
+		return 0
 	fi
 
 	# The wrapper scripts exec the server processes, so these are the server
@@ -26,6 +25,14 @@ shutdown() {
 	wait "${pids[@]}" 2>/dev/null || true
 	kill "$watchdog_pid" 2>/dev/null || true
 	wait "$watchdog_pid" 2>/dev/null || true
+}
+
+# Graceful shutdown: forward SIGTERM/SIGINT to all background jobs.
+shutdown() {
+	# Avoid re-entering the handler if another signal arrives while waiting.
+	trap - SIGTERM SIGINT
+	echo "Shutting down..."
+	stop_components
 	exit 0
 }
 trap shutdown SIGTERM SIGINT
@@ -148,6 +155,7 @@ while [[ $all_ready == false ]]; do
 		if [[ ${service_ready[$service]} == false ]] && ! pid_is_running "${component_pids[$service]}"; then
 			echo "Error: ${service^} exited before becoming ready." >&2
 			echo "Re-run with ENABLE_LOGS_${service^^}=true (or ENABLE_LOGS_ALL=true) to see its output." >&2
+			stop_components
 			exit 1
 		fi
 	done

--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -42,24 +42,33 @@ start_component() {
 	eval "start_time_${component}=${start_time}"
 }
 
-# Start all components and record their start times
+# Start all components and record their start times, keeping the PID of
+# each so a component that exits before it becomes ready can be detected.
+declare -A component_pids
+
 start_component "grafana"
 ./run-grafana.sh &
+component_pids[grafana]=$!
 
 start_component "loki"
 ./run-loki.sh &
+component_pids[loki]=$!
 
 start_component "otelcol"
 ./run-otelcol.sh &
+component_pids[otelcol]=$!
 
 start_component "prometheus"
 ./run-prometheus.sh &
+component_pids[prometheus]=$!
 
 start_component "tempo"
 ./run-tempo.sh &
+component_pids[tempo]=$!
 
 start_component "pyroscope"
 ./run-pyroscope.sh &
+component_pids[pyroscope]=$!
 
 if [[ ${ENABLE_OBI:-false} == "true" ]]; then
 	start_component "obi"
@@ -113,12 +122,34 @@ check_service_ready() {
 	return 1
 }
 
+# Function to check if a component's process is still among the running
+# background jobs (as opposed to having already exited).
+pid_is_running() {
+	local target=$1
+	local pid
+	for pid in "${running_pids[@]}"; do
+		[[ ${pid} == "${target}" ]] && return 0
+	done
+	return 1
+}
+
 # Wait for all services to be ready
 all_ready=false
 while [[ $all_ready == false ]]; do
 	# Check each service
 	for service in "${!services[@]}"; do
 		check_service_ready "$service" "${services[$service]}"
+	done
+
+	# Fail fast if a component's process has already exited, rather than
+	# waiting forever for a health check that will never succeed.
+	mapfile -t running_pids < <(jobs -pr)
+	for service in "${!services[@]}"; do
+		if [[ ${service_ready[$service]} == false ]] && ! pid_is_running "${component_pids[$service]}"; then
+			echo "Error: ${service^} exited before becoming ready." >&2
+			echo "Re-run with ENABLE_LOGS_${service^^}=true (or ENABLE_LOGS_ALL=true) to see its output." >&2
+			exit 1
+		fi
 	done
 
 	# Check if all services are ready


### PR DESCRIPTION
- Check for whether a service process terminated.
- Print a message to the terminal suggesting the user enable logging to try to debug why a service is failing to start.
- Add valid example for configuring Loki to retain logs for 90 days.

Resolves #1710.
