### PR TITLE
fix: validate Renovate workflow dependencies

### DIFF
--- a/.github/config/flint.toml
+++ b/.github/config/flint.toml
@@ -2,4 +2,4 @@
 exclude = ["**/package-lock.json"]
 
 [checks.renovate-deps]
-exclude_managers = ["github-actions", "github-runners"]
+exclude_managers = ["github-runners"]

--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -4,13 +4,13 @@
       "packageName": "grafana/grafana",
       "datasource": "github-releases"
     },
-    "loki": {
-      "packageName": "grafana/loki",
-      "datasource": "github-releases"
-    },
     "grafana/otel-lgtm": {
       "packageName": "grafana/otel-lgtm",
       "datasource": "docker"
+    },
+    "loki": {
+      "packageName": "grafana/loki",
+      "datasource": "github-releases"
     },
     "obi": {
       "packageName": "open-telemetry/opentelemetry-ebpf-instrumentation",
@@ -40,23 +40,75 @@
       ]
     },
     ".github/workflows/acceptance-tests.yml": {
-      "regex": [
-        "mise"
+      "github-actions": [
+        "actions/checkout",
+        "jdx/mise",
+        "jdx/mise-action",
+        "ubuntu"
       ]
     },
     ".github/workflows/ci.yml": {
-      "regex": [
-        "mise"
+      "github-actions": [
+        "actions/checkout",
+        "jdx/mise",
+        "jdx/mise-action",
+        "ubuntu"
+      ]
+    },
+    ".github/workflows/codeql.yml": {
+      "github-actions": [
+        "actions/checkout",
+        "github/codeql-action",
+        "ubuntu"
+      ]
+    },
+    ".github/workflows/container-scan.yml": {
+      "github-actions": [
+        "aquasecurity/trivy",
+        "aquasecurity/trivy-action",
+        "github/codeql-action",
+        "ubuntu"
       ]
     },
     ".github/workflows/ghcr-image-build-and-publish.yml": {
+      "github-actions": [
+        "actions/attest",
+        "actions/checkout",
+        "docker/build-push-action",
+        "docker/login-action",
+        "docker/metadata-action",
+        "docker/setup-buildx-action",
+        "sigstore/cosign",
+        "sigstore/cosign-installer",
+        "ubuntu"
+      ],
       "regex": [
         "cosign"
       ]
     },
+    ".github/workflows/publish-release.yml": {
+      "github-actions": [
+        "actions/github-script",
+        "grafana/shared-workflows",
+        "ubuntu"
+      ]
+    },
     ".github/workflows/release.yml": {
+      "github-actions": [
+        "actions/checkout",
+        "grafana/shared-workflows",
+        "sigstore/cosign",
+        "sigstore/cosign-installer",
+        "ubuntu"
+      ],
       "regex": [
         "cosign"
+      ]
+    },
+    ".github/workflows/scheduled-release.yml": {
+      "github-actions": [
+        "actions/checkout",
+        "ubuntu"
       ]
     },
     "docker/Dockerfile": {
@@ -319,16 +371,6 @@
         "go"
       ]
     },
-    "nomad/README.md": {
-      "regex": [
-        "grafana/otel-lgtm"
-      ]
-    },
-    "nomad/lgtm.nomad.hcl": {
-      "regex": [
-        "grafana/otel-lgtm"
-      ]
-    },
     "mise.toml": {
       "mise": [
         "actionlint",
@@ -358,6 +400,90 @@
         "taplo",
         "typos"
       ]
+    },
+    "nomad/README.md": {
+      "regex": [
+        "grafana/otel-lgtm"
+      ]
+    },
+    "nomad/lgtm.nomad.hcl": {
+      "regex": [
+        "grafana/otel-lgtm"
+      ]
+    }
+  },
+  "actionMeta": {
+    "actions/attest": {
+      "packageName": "actions/attest",
+      "refKind": "version-tag"
+    },
+    "actions/checkout": {
+      "packageName": "actions/checkout",
+      "refKind": "version-tag"
+    },
+    "actions/github-script": {
+      "packageName": "actions/github-script",
+      "refKind": "version-tag"
+    },
+    "aquasecurity/trivy-action": {
+      "packageName": "aquasecurity/trivy-action",
+      "refKind": "version-tag"
+    },
+    "docker/build-push-action": {
+      "packageName": "docker/build-push-action",
+      "refKind": "version-tag"
+    },
+    "docker/login-action": {
+      "packageName": "docker/login-action",
+      "refKind": "version-tag"
+    },
+    "docker/metadata-action": {
+      "packageName": "docker/metadata-action",
+      "refKind": "version-tag"
+    },
+    "docker/setup-buildx-action": {
+      "packageName": "docker/setup-buildx-action",
+      "refKind": "version-tag"
+    },
+    "github/codeql-action/analyze": {
+      "packageName": "github/codeql-action",
+      "refKind": "version-tag"
+    },
+    "github/codeql-action/init": {
+      "packageName": "github/codeql-action",
+      "refKind": "version-tag"
+    },
+    "github/codeql-action/upload-sarif": {
+      "packageName": "github/codeql-action",
+      "refKind": "version-tag"
+    },
+    "grafana/shared-workflows/.github/workflows/sign-and-attest.yml": {
+      "packageName": "grafana/shared-workflows",
+      "refKind": "branch",
+      "ref": "main"
+    },
+    "grafana/shared-workflows/actions/create-github-app-token": {
+      "packageName": "grafana/shared-workflows",
+      "refKind": "version-tag",
+      "compatibility": "create-github-app-token"
+    },
+    "grafana/shared-workflows/actions/docker-build-push-image": {
+      "packageName": "grafana/shared-workflows",
+      "refKind": "version-tag",
+      "compatibility": "docker-build-push-image"
+    },
+    "grafana/shared-workflows/actions/wait-for-docker-publish": {
+      "packageName": "grafana/shared-workflows",
+      "refKind": "version-tag",
+      "compatibility": "wait-for-docker-publish"
+    },
+    "jdx/mise-action": {
+      "packageName": "jdx/mise-action",
+      "refKind": "version-tag"
+    },
+    "sigstore/cosign-installer": {
+      "packageName": "sigstore/cosign-installer",
+      "refKind": "version-tag"
     }
   }
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,7 +5,7 @@
     "customManagers:dockerfileVersions",
     "customManagers:githubActionsVersions",
     "helpers:pinGitHubActionDigestsToSemver",
-    "github>grafana/flint#v0.22.10"
+    "github>grafana/flint#v0.22.11"
   ],
   branchPrefix: "grafanarenovatebot/",
   dependencyDashboard: true,
@@ -46,6 +46,19 @@
       matchDatasources: ["docker"],
       matchPackageNames: ["docker.io/otel/ebpf-instrument"],
       enabled: false
+    },
+    {
+      // aquasecurity/trivy-action has duplicate 0.35.0 tags that break github-tags lookups
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["aquasecurity/trivy-action"],
+      overrideDatasource: "github-releases"
+    },
+    {
+      // Branch-pinned shared workflows must use digest updates, not the monorepo tags
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["grafana/shared-workflows"],
+      matchCurrentValue: "main",
+      overrideDatasource: "github-digest"
     },
     {
       extends: ["monorepo:dotnet"],

--- a/mise.lock
+++ b/mise.lock
@@ -47,49 +47,49 @@ url_api = "https://api.github.com/repos/rhysd/actionlint/releases/assets/3849249
 provenance = "github-attestations"
 
 [[tools."aqua:grafana/flint"]]
-version = "0.22.10"
+version = "0.22.11"
 backend = "aqua:grafana/flint"
 
 [tools."aqua:grafana/flint"."platforms.linux-arm64"]
-checksum = "sha256:6dec82cb6486b7e645e0b1674493497191d92a8e28c5c79194e5553882d213de"
-url = "https://github.com/grafana/flint/releases/download/v0.22.10/flint-aarch64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/grafana/flint/releases/assets/491750275"
+checksum = "sha256:a197969873591f857833f7c71ab66506a4050e0a12cf1872b09741652d20e99c"
+url = "https://github.com/grafana/flint/releases/download/v0.22.11/flint-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/grafana/flint/releases/assets/522530497"
 provenance = "github-attestations"
 
 [tools."aqua:grafana/flint"."platforms.linux-arm64-musl"]
-checksum = "sha256:373060c08a4cdd905d6e8e83f62ef43da8778d9133cb66b7801f392587812e8f"
-url = "https://github.com/grafana/flint/releases/download/v0.22.10/flint-aarch64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/grafana/flint/releases/assets/491750193"
+checksum = "sha256:1797194efc0843a0a2c001a235ca91cc09aee9a5a7dc74d25c190ae42445099b"
+url = "https://github.com/grafana/flint/releases/download/v0.22.11/flint-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/grafana/flint/releases/assets/522530700"
 provenance = "github-attestations"
 
 [tools."aqua:grafana/flint"."platforms.linux-x64"]
-checksum = "sha256:a9f7f3768ec02cdd082c12cea0e815fc142d3ee721f4d8485f4ba9fc2c7d0521"
-url = "https://github.com/grafana/flint/releases/download/v0.22.10/flint-x86_64-unknown-linux-gnu.tar.gz"
-url_api = "https://api.github.com/repos/grafana/flint/releases/assets/491749844"
+checksum = "sha256:8c2400345fee126864183b96f8ec8a0f646b2c09abcd9ff25c7a0e56caa6f822"
+url = "https://github.com/grafana/flint/releases/download/v0.22.11/flint-x86_64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/grafana/flint/releases/assets/522529698"
 provenance = "github-attestations"
 
 [tools."aqua:grafana/flint"."platforms.linux-x64-musl"]
-checksum = "sha256:3b174b31f10b1ded2cf0a54e8b62e5526713a49816c1fd74b00073519044f7bb"
-url = "https://github.com/grafana/flint/releases/download/v0.22.10/flint-x86_64-unknown-linux-musl.tar.gz"
-url_api = "https://api.github.com/repos/grafana/flint/releases/assets/491750257"
+checksum = "sha256:bde67006096e2c38d4140d6362a6a83a9047cbe8bd1e4fcdeb7e7c0166b0f02c"
+url = "https://github.com/grafana/flint/releases/download/v0.22.11/flint-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/grafana/flint/releases/assets/522530534"
 provenance = "github-attestations"
 
 [tools."aqua:grafana/flint"."platforms.macos-arm64"]
-checksum = "sha256:f9aa1a95aa5953f7f5a64c0d72f86e634c4930e9cb73422a95e342c6cb9be5d5"
-url = "https://github.com/grafana/flint/releases/download/v0.22.10/flint-aarch64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/grafana/flint/releases/assets/491750245"
+checksum = "sha256:a93e428a2561af80bad79810ce23dbab13e9d39519bfdbb6625e902d2b06f8fa"
+url = "https://github.com/grafana/flint/releases/download/v0.22.11/flint-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/grafana/flint/releases/assets/522531026"
 provenance = "github-attestations"
 
 [tools."aqua:grafana/flint"."platforms.macos-x64"]
-checksum = "sha256:b55731f1b74196afea675bdbd6ebbbd94171b4e9d31f79ecee36372bdf8818cf"
-url = "https://github.com/grafana/flint/releases/download/v0.22.10/flint-x86_64-apple-darwin.tar.gz"
-url_api = "https://api.github.com/repos/grafana/flint/releases/assets/491752660"
+checksum = "sha256:c42ceb2cc835ec37b04f78215c243ebd24109f713757fbfffe7e4bc0c537a2ac"
+url = "https://github.com/grafana/flint/releases/download/v0.22.11/flint-x86_64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/grafana/flint/releases/assets/522533290"
 provenance = "github-attestations"
 
 [tools."aqua:grafana/flint"."platforms.windows-x64"]
-checksum = "sha256:494f16ad4d2d8eae137438832e544675d196a2887086ab8070a5a346d70650be"
-url = "https://github.com/grafana/flint/releases/download/v0.22.10/flint-x86_64-pc-windows-msvc.zip"
-url_api = "https://api.github.com/repos/grafana/flint/releases/assets/491751016"
+checksum = "sha256:7474be1f55fc003dedf5e49da55f65b490f7783b49e6322cfabfb95930baba1a"
+url = "https://github.com/grafana/flint/releases/download/v0.22.11/flint-x86_64-pc-windows-msvc.zip"
+url_api = "https://api.github.com/repos/grafana/flint/releases/assets/522531464"
 provenance = "github-attestations"
 
 [[tools."aqua:grafana/gcx"]]

--- a/mise.toml
+++ b/mise.toml
@@ -11,7 +11,7 @@ rust = { version = "1.97.1", components = "clippy,rustfmt" }
 
 # Linters
 actionlint = "1.7.12"
-"aqua:grafana/flint" = "0.22.10"
+"aqua:grafana/flint" = "0.22.11"
 "aqua:jonwiggins/xmloxide" = "0.4.4"
 "aqua:owenlamont/ryl" = "0.21.0"
 biome = "2.5.6"


### PR DESCRIPTION
## Summary

- override Renovate lookup behavior for `aquasecurity/trivy-action` and `grafana/shared-workflows@main`
- update Flint to v0.22.11
- enable GitHub Actions coverage in the Renovate dependency snapshot
- regenerate the tracked-dependencies snapshot

Fixes #920.

## Verification

- `mise run lint:fix`
- `mise run lint`
- `git diff --check`
- Renovate dry-run with the central shared-workflows rule reproduced and verified both local overrides
- negative Flint checks reproduced failures for an invalid action tag and invalid shared-workflows digest lookup